### PR TITLE
chore: Add CI workflow for build and test on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: swift build
+
+      - name: Test
+        run: swift test


### PR DESCRIPTION
## 概要

`develop` および `main` へのPRをトリガーとして、ビルドとテストを自動実行するCIワークフローを追加しました。

## 変更内容

- `.github/workflows/ci.yml`: GitHub Actions CI設定
  - トリガー: `develop` / `main` へのPR
  - ランナー: `macos-15`
  - ステップ: `swift build` → `swift test`

## チェックリスト

- [x] コミットメッセージが規則に従っている