### PR TITLE
fix: Make AXManager Sendable to allow capture in background closures

### DIFF
--- a/Sources/Vimursor/Accessibility/AXManager.swift
+++ b/Sources/Vimursor/Accessibility/AXManager.swift
@@ -28,7 +28,7 @@ struct SearchElementInfo: Sendable {
     }
 }
 
-final class AXManager {
+final class AXManager: @unchecked Sendable {
     /// バックグラウンドで列挙し、メインスレッドで completion を呼ぶ
     func fetchClickableElements(in app: AXUIElement, completion: @escaping @Sendable ([AXElement]) -> Void) {
         let wrapped = AXElement(ref: app)


### PR DESCRIPTION
## 概要

CI（Swift 6.0）で `AXManager` が `Sendable` に適合していないため、`DispatchQueue.global` クロージャでキャプチャできないエラーを修正しました。

## 変更内容

- `AXManager` に `@unchecked Sendable` を追加
- `AXManager` は mutable な状態を持たないため、安全に適用可能

## テスト

- [x] `swift build` 通過確認済み