### PR TITLE
fix: v0.4 ヒントモード複数バグ修正

### DIFF
--- a/Sources/Vimursor/Accessibility/AXManager.swift
+++ b/Sources/Vimursor/Accessibility/AXManager.swift
@@ -89,25 +89,6 @@ final class AXManager: @unchecked Sendable {
         }
     }
 
-    // カーソルを要素の中心に移動（視覚的フィードバック用）
-    @MainActor
-    func moveCursor(to frame: CGRect) {
-        let screenHeight = NSScreen.main?.frame.height ?? 0
-        let point = AXManager.centerScreenPoint(from: frame, screenHeight: screenHeight)
-        let move = CGEvent(mouseEventSource: nil, mouseType: .mouseMoved,
-                           mouseCursorPosition: point, mouseButton: .left)
-        move?.post(tap: .cghidEventTap)
-    }
-
-    // AXPress（セマンティック）を試み、失敗時は座標クリックにフォールバック
-    @MainActor
-    func press(element: AXUIElement, frame: CGRect) {
-        moveCursor(to: frame)
-        if AXUIElementPerformAction(element, "AXPress" as CFString) != .success {
-            clickAt(frame: frame)
-        }
-    }
-
     @MainActor
     func clickAt(frame: CGRect) {
         let screenHeight = NSScreen.main?.frame.height ?? 0

--- a/Sources/Vimursor/Accessibility/AXManager.swift
+++ b/Sources/Vimursor/Accessibility/AXManager.swift
@@ -89,8 +89,23 @@ final class AXManager: @unchecked Sendable {
         }
     }
 
-    func click(element: AXUIElement) {
-        AXUIElementPerformAction(element, "AXPress" as CFString)
+    // カーソルを要素の中心に移動（視覚的フィードバック用）
+    @MainActor
+    func moveCursor(to frame: CGRect) {
+        let screenHeight = NSScreen.main?.frame.height ?? 0
+        let point = AXManager.centerScreenPoint(from: frame, screenHeight: screenHeight)
+        let move = CGEvent(mouseEventSource: nil, mouseType: .mouseMoved,
+                           mouseCursorPosition: point, mouseButton: .left)
+        move?.post(tap: .cghidEventTap)
+    }
+
+    // AXPress（セマンティック）を試み、失敗時は座標クリックにフォールバック
+    @MainActor
+    func press(element: AXUIElement, frame: CGRect) {
+        moveCursor(to: frame)
+        if AXUIElementPerformAction(element, "AXPress" as CFString) != .success {
+            clickAt(frame: frame)
+        }
     }
 
     @MainActor

--- a/Sources/Vimursor/Accessibility/UIElementEnumerator.swift
+++ b/Sources/Vimursor/Accessibility/UIElementEnumerator.swift
@@ -3,8 +3,14 @@ import AppKit
 enum UIElementEnumerator {
     private static let clickableRoles: Set<String> = [
         "AXButton", "AXLink", "AXCheckBox", "AXRadioButton",
-        "AXMenuItem", "AXPopUpButton", "AXTextField", "AXComboBox",
-        "AXTab", "AXCell"
+        "AXMenuItem", "AXPopUpButton", "AXComboBox", "AXTab"
+    ]
+
+    // これらのロールはクリック不能と確定 → AXPress チェックをスキップして高速化
+    private static let skippableRoles: Set<String> = [
+        "AXStaticText", "AXImage", "AXSeparator", "AXScrollBar",
+        "AXScrollArea", "AXSplitter", "AXToolbar", "AXStatusBar",
+        "AXTable", "AXOutline", "AXList", "AXBrowser"
     ]
 
     static func enumerateClickableElements(root: AXUIElement) -> [AXUIElement] {
@@ -18,7 +24,7 @@ enum UIElementEnumerator {
         into result: inout [AXUIElement],
         depth: Int
     ) {
-        guard depth < 20 else { return }  // 無限再帰防止
+        guard depth < 25 else { return }  // 無限再帰防止
 
         if isClickable(element: element) {
             result.append(element)
@@ -33,11 +39,28 @@ enum UIElementEnumerator {
         }
     }
 
+    // ロール先頭チェックで IPC 呼び出し数を最小化
+    // skip-list → 1 IPC、clickableRoles → 2 IPC、不明ロール → 3 IPC（Electron 対応）
     private static func isClickable(element: AXUIElement) -> Bool {
         var roleRef: CFTypeRef?
-        let err = AXUIElementCopyAttributeValue(element, "AXRole" as CFString, &roleRef)
-        guard err == .success, let role = roleRef as? String else { return false }
-        return clickableRoles.contains(role)
+        if AXUIElementCopyAttributeValue(element, "AXRole" as CFString, &roleRef) == .success,
+           let role = roleRef as? String {
+            if skippableRoles.contains(role) { return false }
+            if clickableRoles.contains(role) { return isEnabled(element: element) }
+        }
+        guard isEnabled(element: element) else { return false }
+        var actionsRef: CFArray?
+        guard AXUIElementCopyActionNames(element, &actionsRef) == .success,
+              let actions = actionsRef as? [String] else { return false }
+        return actions.contains("AXPress")
+    }
+
+    // AXEnabled = false の要素はクリック不能なのでスキップ（属性なければ有効とみなす）
+    private static func isEnabled(element: AXUIElement) -> Bool {
+        var ref: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, "AXEnabled" as CFString, &ref) == .success,
+              let enabled = ref as? Bool else { return true }
+        return enabled
     }
 
     static func enumerateSearchableElements(root: AXUIElement) -> [AXUIElement] {

--- a/Sources/Vimursor/HintMode/HintModeController.swift
+++ b/Sources/Vimursor/HintMode/HintModeController.swift
@@ -98,10 +98,9 @@ final class HintModeController {
 
         if let exact = matches.first(where: { $0.label == newInput }) {
             let frame = exact.frame
-            let element = exact.axElement.ref
             deactivate()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
-                self?.axManager.press(element: element, frame: frame)
+                self?.axManager.clickAt(frame: frame)
             }
             return
         }

--- a/Sources/Vimursor/HintMode/HintModeController.swift
+++ b/Sources/Vimursor/HintMode/HintModeController.swift
@@ -2,6 +2,7 @@ import AppKit
 
 private enum HintModeState {
     case inactive
+    case fetching   // 要素取得中。この状態でも activate() を弾く
     case active(hints: [UIElementInfo], input: String)
 }
 
@@ -15,11 +16,9 @@ final class HintModeController {
     private weak var overlayWindow: OverlayWindow?
     private weak var hotkeyManager: HotkeyManager?
 
-    // CGEventTapスレッドから読まれる（書き込みはメインスレッドのみ）
-    private var isActive: Bool = false
-
     func activate(overlayWindow: OverlayWindow, hotkeyManager: HotkeyManager) {
-        guard !isActive else { return }
+        guard case .inactive = state else { return }  // fetching / active 中はスキップ
+        state = .fetching                              // 同期的に状態変更（二重起動防止）
 
         self.overlayWindow = overlayWindow
         self.hotkeyManager = hotkeyManager
@@ -39,13 +38,15 @@ final class HintModeController {
         overlayWindow: OverlayWindow,
         hotkeyManager: HotkeyManager
     ) {
-        guard !elements.isEmpty else { return }
+        guard !elements.isEmpty else {
+            state = .inactive  // 要素がなければ inactive に戻す
+            return
+        }
 
         let labels = LabelGenerator.generateLabels(count: elements.count)
         let hints = axManager.buildUIElementInfos(elements: elements, labels: labels)
 
         state = .active(hints: hints, input: "")
-        isActive = true
 
         let view = HintView(frame: overlayWindow.contentView?.bounds ?? .zero)
         view.autoresizingMask = [.width, .height]
@@ -66,7 +67,6 @@ final class HintModeController {
     }
 
     func deactivate() {
-        isActive = false
         state = .inactive
         hintView?.removeFromSuperview()
         hintView = nil
@@ -97,10 +97,11 @@ final class HintModeController {
         }
 
         if let exact = matches.first(where: { $0.label == newInput }) {
+            let frame = exact.frame
             let element = exact.axElement.ref
             deactivate()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
-                self?.axManager.click(element: element)
+                self?.axManager.press(element: element, frame: frame)
             }
             return
         }

--- a/Sources/Vimursor/HintMode/HintModeController.swift
+++ b/Sources/Vimursor/HintMode/HintModeController.swift
@@ -23,7 +23,10 @@ final class HintModeController {
         self.overlayWindow = overlayWindow
         self.hotkeyManager = hotkeyManager
 
-        guard let focusedApp = NSWorkspace.shared.frontmostApplication else { return }
+        guard let focusedApp = NSWorkspace.shared.frontmostApplication else {
+            state = .inactive
+            return
+        }
         let appElement = AXUIElementCreateApplication(focusedApp.processIdentifier)
 
         axManager.fetchClickableElements(in: appElement) { [weak self] elements in

--- a/Sources/Vimursor/HotkeyManager.swift
+++ b/Sources/Vimursor/HotkeyManager.swift
@@ -17,8 +17,23 @@ final class HotkeyManager: @unchecked Sendable {
     var onHintModeActivated: (() -> Void)?
     var onSearchModeActivated: (() -> Void)?
     var onScrollModeActivated: (() -> Void)?
-    // HintMode/SearchMode中にキー入力を委譲するハンドラ（true=消費, false=通常処理）
-    var keyEventHandler: ((CGKeyCode, CGEventFlags) -> Bool)?
+
+    // CGEventTap スレッド（読み取り）とメインスレッド（書き込み）をまたぐため NSLock で保護
+    private let handlerLock = NSLock()
+    private var _keyEventHandler: ((CGKeyCode, CGEventFlags) -> Bool)?
+    var keyEventHandler: ((CGKeyCode, CGEventFlags) -> Bool)? {
+        get {
+            handlerLock.lock()
+            defer { handlerLock.unlock() }
+            return _keyEventHandler
+        }
+        set {
+            handlerLock.lock()
+            defer { handlerLock.unlock() }
+            _keyEventHandler = newValue
+        }
+    }
+
     private var eventTap: CFMachPort?
 
     func start() {

--- a/Sources/Vimursor/Overlay/LabelGenerator.swift
+++ b/Sources/Vimursor/Overlay/LabelGenerator.swift
@@ -3,20 +3,21 @@ struct LabelGenerator {
 
     static func generateLabels(count: Int) -> [String] {
         guard count > 0 else { return [] }
+        let clampedCount = min(count, chars.count * chars.count)
 
         // count が chars 数以下なら全部1文字ラベル（prefix 競合なし）
-        if count <= chars.count {
-            return chars.prefix(count).map { String($0) }
+        if clampedCount <= chars.count {
+            return chars.prefix(clampedCount).map { String($0) }
         }
 
         // count が多い場合は全部2文字ラベル（最大 16×16 = 256）
         var labels: [String] = []
         for first in chars {
             for second in chars {
-                guard labels.count < count else { break }
+                guard labels.count < clampedCount else { break }
                 labels.append(String(first) + String(second))
             }
-            if labels.count >= count { break }
+            if labels.count >= clampedCount { break }
         }
         return labels
     }

--- a/Sources/Vimursor/Overlay/LabelGenerator.swift
+++ b/Sources/Vimursor/Overlay/LabelGenerator.swift
@@ -1,28 +1,23 @@
 struct LabelGenerator {
-    private static let chars = "fjrieodksla;nvmc"
+    private static let chars = "fjrieodkslapnvmc"  // `;` → `p` に変更
 
     static func generateLabels(count: Int) -> [String] {
         guard count > 0 else { return [] }
 
+        // count が chars 数以下なら全部1文字ラベル（prefix 競合なし）
+        if count <= chars.count {
+            return chars.prefix(count).map { String($0) }
+        }
+
+        // count が多い場合は全部2文字ラベル（最大 16×16 = 256）
         var labels: [String] = []
-
-        // 1文字ラベル
-        for char in chars {
-            guard labels.count < count else { break }
-            labels.append(String(char))
-        }
-
-        // 2文字ラベル（足りない場合）
-        if labels.count < count {
-            for first in chars {
-                for second in chars {
-                    guard labels.count < count else { break }
-                    labels.append(String(first) + String(second))
-                }
-                if labels.count >= count { break }
+        for first in chars {
+            for second in chars {
+                guard labels.count < count else { break }
+                labels.append(String(first) + String(second))
             }
+            if labels.count >= count { break }
         }
-
         return labels
     }
 }

--- a/Tests/VimursorTests/LabelGeneratorTests.swift
+++ b/Tests/VimursorTests/LabelGeneratorTests.swift
@@ -13,7 +13,7 @@ struct LabelGeneratorTests {
     }
 
     @Test func sixteenLabels() {
-        // chars = "fjrieodksla;nvmc" (16文字) なので count=16 まで1文字ラベル
+        // chars = "fjrieodkslapnvmc" (16文字) なので count=16 まで1文字ラベル
         let labels = LabelGenerator.generateLabels(count: 16)
         #expect(labels.count == 16)
         #expect(labels.allSatisfy { $0.count == 1 })
@@ -21,7 +21,7 @@ struct LabelGeneratorTests {
     }
 
     @Test func seventeenLabelsIncludesTwoChars() {
-        // count=17 で初めて2文字ラベルが登場する
+        // count=17 以上は全部2文字ラベル（prefix-free を保証するため1文字と2文字を混在させない）
         let labels = LabelGenerator.generateLabels(count: 17)
         #expect(labels.count == 17)
         #expect(labels.contains { $0.count == 2 })
@@ -31,5 +31,36 @@ struct LabelGeneratorTests {
     @Test func noDuplicates() {
         let labels = LabelGenerator.generateLabels(count: 100)
         #expect(labels.count == Set(labels).count)
+    }
+
+    // prefix-free: 全ラベルが同じ長さであること
+    @Test func testNoMixedLengthLabels() {
+        let labels = LabelGenerator.generateLabels(count: 20)
+        let lengths = Set(labels.map { $0.count })
+        #expect(lengths.count == 1, "全ラベルが同じ長さであること")
+    }
+
+    // セミコロンが含まれないこと
+    @Test func testNoSemicolon() {
+        let labels = LabelGenerator.generateLabels(count: 256)
+        #expect(!labels.contains { $0.contains(";") })
+    }
+
+    // 16個以下は1文字ラベル
+    @Test func testSingleCharLabelsForSmallCount() {
+        let labels = LabelGenerator.generateLabels(count: 16)
+        #expect(labels.allSatisfy { $0.count == 1 })
+    }
+
+    // 17個以上は全部2文字ラベル
+    @Test func testDoubleCharLabelsForLargeCount() {
+        let labels = LabelGenerator.generateLabels(count: 17)
+        #expect(labels.allSatisfy { $0.count == 2 })
+    }
+
+    // ラベルに重複がないこと（大量生成）
+    @Test func testLabelsAreUniqueForLargeCount() {
+        let labels = LabelGenerator.generateLabels(count: 100)
+        #expect(Set(labels).count == labels.count)
     }
 }

--- a/Tests/VimursorTests/LabelGeneratorTests.swift
+++ b/Tests/VimursorTests/LabelGeneratorTests.swift
@@ -34,32 +34,32 @@ struct LabelGeneratorTests {
     }
 
     // prefix-free: 全ラベルが同じ長さであること
-    @Test func testNoMixedLengthLabels() {
+    @Test func noMixedLengthLabels() {
         let labels = LabelGenerator.generateLabels(count: 20)
         let lengths = Set(labels.map { $0.count })
         #expect(lengths.count == 1, "全ラベルが同じ長さであること")
     }
 
     // セミコロンが含まれないこと
-    @Test func testNoSemicolon() {
+    @Test func noSemicolon() {
         let labels = LabelGenerator.generateLabels(count: 256)
         #expect(!labels.contains { $0.contains(";") })
     }
 
     // 16個以下は1文字ラベル
-    @Test func testSingleCharLabelsForSmallCount() {
+    @Test func singleCharLabelsForSmallCount() {
         let labels = LabelGenerator.generateLabels(count: 16)
         #expect(labels.allSatisfy { $0.count == 1 })
     }
 
     // 17個以上は全部2文字ラベル
-    @Test func testDoubleCharLabelsForLargeCount() {
+    @Test func doubleCharLabelsForLargeCount() {
         let labels = LabelGenerator.generateLabels(count: 17)
         #expect(labels.allSatisfy { $0.count == 2 })
     }
 
     // ラベルに重複がないこと（大量生成）
-    @Test func testLabelsAreUniqueForLargeCount() {
+    @Test func labelsAreUniqueForLargeCount() {
         let labels = LabelGenerator.generateLabels(count: 100)
         #expect(Set(labels).count == labels.count)
     }

--- a/docs/plans/v0.4.md
+++ b/docs/plans/v0.4.md
@@ -1,0 +1,654 @@
+# v0.4 実装プラン — ヒントモード修正
+
+アーキテクチャ・制約の詳細は `overview.md` を参照。
+
+---
+
+## v0.4 の完了条件
+
+1. 17要素以上のアプリでヒントモードを使ったとき、2文字ラベル（例: `fr`）が正しく入力・選択できる
+2. ラベルに `;` が含まれない（入力不能なラベルが生成されない）
+3. Chrome / Obsidian 等の Electron アプリでヒント要素を検出できる（`AXPress` アクションベース）
+4. `AXEnabled = false` の無効要素にはヒントが表示されない
+5. ヒントモードの連打（素早く2回 `Cmd+Shift+Space`）で状態が壊れない
+6. `keyEventHandler` の読み書きがスレッドセーフになる
+7. Chrome の Google 検索結果リンク等、コンテナ+子リンク構造の要素を正しく選択・クリックできる
+
+---
+
+## 修正箇所一覧
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `Sources/Vimursor/Overlay/LabelGenerator.swift` | `;` 除去、prefix-free 化 |
+| `Sources/Vimursor/Accessibility/UIElementEnumerator.swift` | アクションベース検出、`AXEnabled` チェック、深さ上限拡張 |
+| `Sources/Vimursor/HintMode/HintModeController.swift` | `isActive` 除去・`.fetching` 状態追加による二重起動防止 |
+| `Sources/Vimursor/HotkeyManager.swift` | `NSLock` で `keyEventHandler` をスレッドセーフ化 |
+| `Tests/VimursorTests/LabelGeneratorTests.swift` | prefix-free・`;` なしの検証テスト追加 |
+
+---
+
+## Phase 1: LabelGenerator の修正
+
+### 現状の問題
+
+`LabelGenerator` は現在、要素数が16を超えると1文字ラベルと2文字ラベルを**混在**させて生成する。
+
+```swift
+// 現在の実装（LabelGenerator.swift）
+private static let chars = "fjrieodksla;nvmc"  // 16文字
+
+static func generateLabels(count: Int) -> [String] {
+    // まず1文字ラベルを割り当て（最大16個）
+    for char in chars { labels.append(String(char)) }
+
+    // 足りなければ2文字ラベルを追加
+    // → 結果: ["f","j","r",...,"c", "ff","fj","fr",...]
+    //   1文字 "f" と 2文字 "ff","fj","fr" が共存する
+}
+```
+
+この設計だと、`HintModeController.handleKey` での処理で矛盾が生じる。
+
+```swift
+// HintModeController.swift の handleKey（現状）
+let newInput = input + char                                   // 例: "f"
+let matches = hints.filter { $0.label.hasPrefix(newInput) }  // ["f", "ff", "fj", "fr", ...]
+
+if let exact = matches.first(where: { $0.label == newInput }) {
+    // "f" == "f" → 即座にマッチ → deactivate + click!
+    // ユーザーは "fr" を入力しようとしていたが、"f" を押した瞬間に終了してしまう
+}
+```
+
+**症状:** 17要素以上のアプリ（例: Chrome）でヒントモードを使うと、2文字ラベル（例: `fr`）の最初の文字（`f`）を押した時点で別の要素がクリックされ、`fr` に到達できない。
+
+加えて、`chars` に含まれる `;`（セミコロン）は `HintModeController.keyCodeToChar` のマッピングに存在しない。
+
+```swift
+// HintModeController.swift の keyCodeToChar（現状）
+let map: [CGKeyCode: String] = [
+    0: "a", 11: "b", 8: "c", 2: "d", 14: "e",
+    3: "f", 5: "g", 4: "h", 34: "i", 38: "j",
+    40: "k", 37: "l", 46: "m", 45: "n", 31: "o",
+    35: "p", 12: "q", 15: "r", 1: "s", 17: "t",
+    32: "u", 9: "v", 13: "w", 7: "x", 16: "y", 6: "z"
+    // ← `;` のキーコードが存在しない
+]
+```
+
+**症状:** 要素数が12番目（`;`に割り当てられる位置）以降になると、ラベル `;` を持つ要素は永遠に選択できない。
+
+### 修正方針
+
+**問題1（prefix 競合）:** 1文字と2文字を混在させるのをやめ、count が `chars.count`（16）以下なら全部1文字、超えるなら全部2文字にする。こうすることで prefix の衝突が構造上起こりえなくなる。
+
+**問題2（`;` の除去）:** `;` を `keyCodeToChar` に存在する `p`（キーコード: 35）に置き換える。
+
+### 修正後のコード
+
+```swift
+// LabelGenerator.swift
+struct LabelGenerator {
+    private static let chars = "fjrieodkslapnvmc"  // `;` → `p` に変更
+
+    static func generateLabels(count: Int) -> [String] {
+        guard count > 0 else { return [] }
+
+        // count が chars 数以下なら全部1文字ラベル（prefix 競合なし）
+        if count <= chars.count {
+            return chars.prefix(count).map { String($0) }
+        }
+
+        // count が多い場合は全部2文字ラベル（最大 16×16 = 256）
+        var labels: [String] = []
+        for first in chars {
+            for second in chars {
+                guard labels.count < count else { break }
+                labels.append(String(first) + String(second))
+            }
+            if labels.count >= count { break }
+        }
+        return labels
+    }
+}
+```
+
+**設計上のトレードオフ:** 17要素から急に2キー入力になる（16→17で UX が変わる）。ただし「fを押したら別の要素が選択された」という致命的バグより許容できる。最大 256 要素まで対応（ほとんどのアプリで十分）。
+
+---
+
+## Phase 2: UIElementEnumerator の修正
+
+### 現状の問題
+
+`UIElementEnumerator` は現在、クリック可能要素をロール（AXRole）の allowlist で判断している。
+
+```swift
+// UIElementEnumerator.swift（現状）
+private static let clickableRoles: Set<String> = [
+    "AXButton", "AXLink", "AXCheckBox", "AXRadioButton",
+    "AXMenuItem", "AXPopUpButton", "AXTextField", "AXComboBox",
+    "AXTab", "AXCell"
+]
+
+private static func isClickable(element: AXUIElement) -> Bool {
+    var roleRef: CFTypeRef?
+    let err = AXUIElementCopyAttributeValue(element, "AXRole" as CFString, &roleRef)
+    guard err == .success, let role = roleRef as? String else { return false }
+    return clickableRoles.contains(role)
+}
+```
+
+この方針には2つの問題がある。
+
+**問題1 — Electron アプリ（Chrome・Obsidian 等）でヒントが出ない:**
+Chrome / Obsidian は Electron（Chromium ベース）で動いており、Web コンテンツの AX ロールは `AXGenericElement`・`AXGroup` 等の非標準ロールになる。これらは allowlist に含まれないため、クリック可能であっても検出されない。
+
+**問題2 — 無効要素（グレーアウトボタン等）にもヒントが表示される:**
+`AXEnabled = false` の要素（押せないグレーアウトボタン等）もロールが一致すれば収集してしまう。ユーザーがそのヒントを選択してもクリックが効かない。
+
+また、深さ上限が `depth < 20` に設定されており、Web コンテンツの深い AX ツリー（20 階層を超えることがある）には到達できないケースがある。
+
+### 修正方針
+
+**問題1（Electron 対応）:** ロールの allowlist を廃止し、`AXUIElementCopyActionNames` で取得したアクション一覧に `"AXPress"` が含まれるかで判断する。`AXPress` を持つ要素は OS レベルで「押せる」要素であることが保証されており、プラットフォーム・フレームワーク非依存の判定になる。Homerow も同様のアプローチを採用している。
+
+**問題2（無効要素の除外）:** `AXEnabled` 属性を確認し、`false` の要素はスキップする。
+
+**深さ上限:** `20` → `50` に拡張する。
+
+### 修正後のコード
+
+```swift
+// UIElementEnumerator.swift
+static func enumerateClickableElements(root: AXUIElement) -> [AXUIElement] {
+    var result: [AXUIElement] = []
+    collectClickable(element: root, into: &result, depth: 0)
+    return result
+}
+
+private static func collectClickable(
+    element: AXUIElement,
+    into result: inout [AXUIElement],
+    depth: Int
+) {
+    guard depth < 50 else { return }  // 20 → 50 に拡張
+
+    if isClickable(element: element) {
+        result.append(element)
+    }
+
+    var childrenRef: CFTypeRef?
+    let err = AXUIElementCopyAttributeValue(element, "AXChildren" as CFString, &childrenRef)
+    guard err == .success, let children = childrenRef as? [AXUIElement] else { return }
+
+    for child in children {
+        collectClickable(element: child, into: &result, depth: depth + 1)
+    }
+}
+
+// ロールではなく AXPress アクションの有無で判定
+private static func isClickable(element: AXUIElement) -> Bool {
+    guard isEnabled(element: element) else { return false }
+    var actionsRef: CFTypeRef?
+    guard AXUIElementCopyActionNames(element, &actionsRef) == .success,
+          let actions = actionsRef as? [String] else { return false }
+    return actions.contains("AXPress")
+}
+
+// AXEnabled = false の要素はクリック不能なのでスキップ
+private static func isEnabled(element: AXUIElement) -> Bool {
+    var ref: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, "AXEnabled" as CFString, &ref) == .success,
+          let enabled = ref as? Bool else { return true }  // 属性なければ有効とみなす
+    return enabled
+}
+```
+
+**注意:** Chrome のレンダラープロセス分離（Web コンテンツが別プロセスで動作）により、`AXUIElementCreateApplication` から到達できない要素は引き続き存在する。これは AX API の制約であり、完全な解決は困難。`overview.md` に既知の制約として記載済み。
+
+---
+
+## Phase 2.1: Electron アプリの追加修正
+
+Phase 2 実装後の手動確認で判明した2つの問題を修正する。
+
+### 問題1: Chrome でヒントが表示されるがクリックが効かない
+
+`HintModeController` は exact マッチ時に `axManager.click(element:)` を呼ぶ。
+これは `AXUIElementPerformAction(element, "AXPress")` を使うが、Electron アプリの要素は `AXPress` をアクション**リストに持つ**（検出はされる）ものの、実際のアクション呼び出しは Web レンダラーを通じては機能しない。
+
+**修正:** `clickAt(frame:)` に変更する。`UIElementInfo.frame` は既に保持されており、CGEvent ベースの OS レベルクリックを行う。
+
+```swift
+// HintModeController.swift — handleKey の exact マッチ処理
+// 変更前
+let element = exact.axElement.ref
+deactivate()
+DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+    self?.axManager.click(element: element)
+}
+
+// 変更後
+let frame = exact.frame
+deactivate()
+DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+    self?.axManager.clickAt(frame: frame)
+}
+```
+
+### 問題2: Obsidian でヒントが表示されない
+
+Obsidian はシングルプロセス Electron のため要素自体には到達できるはずだが、インタラクティブな要素が `AXPress` をアクションリストに登録していない可能性がある。
+
+**修正:** ハイブリッド検出。`AXPress` 優先 + 標準 clickable ロールをフォールバックとして追加。
+
+```swift
+// UIElementEnumerator.swift
+private static let clickableRoles: Set<String> = [
+    "AXButton", "AXLink", "AXCheckBox", "AXRadioButton",
+    "AXMenuItem", "AXPopUpButton", "AXComboBox", "AXTab"
+]
+
+private static func isClickable(element: AXUIElement) -> Bool {
+    guard isEnabled(element: element) else { return false }
+    // 優先: AXPress アクション（Electron 等の非標準ロール対応）
+    var actionsRef: CFArray?
+    if AXUIElementCopyActionNames(element, &actionsRef) == .success,
+       let actions = actionsRef as? [String],
+       actions.contains("AXPress") { return true }
+    // フォールバック: 標準 clickable ロール（AXPress を持たない要素対応）
+    var roleRef: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, "AXRole" as CFString, &roleRef) == .success,
+          let role = roleRef as? String else { return false }
+    return clickableRoles.contains(role)
+}
+```
+
+**注意:** フォールバック経由で検出された要素のクリックも `clickAt(frame:)` を使うため、問題1の修正と組み合わせることで動作する。
+
+---
+
+## Phase 3: HintModeController の二重起動防止
+
+### 現状の問題
+
+`HintModeController` には `isActive: Bool` と `state: HintModeState` の2つの状態管理変数がある。
+
+```swift
+// HintModeController.swift（現状）
+private var state: HintModeState = .inactive
+private var isActive: Bool = false  // ← state と重複
+```
+
+`activate()` は `isActive` でガードしているが、`isActive = true` がセットされるのは `startHintMode()`（非同期コールバック内）である。
+
+```swift
+func activate(overlayWindow: OverlayWindow, hotkeyManager: HotkeyManager) {
+    guard !isActive else { return }  // ← isActive はまだ false（非同期のため）
+
+    // 非同期で要素取得開始
+    axManager.fetchClickableElements(in: appElement) { [weak self] elements in
+        Task { @MainActor [weak self] in
+            self?.startHintMode(...)  // ← ここで isActive = true になる
+        }
+    }
+}
+
+private func startHintMode(...) {
+    // ...
+    isActive = true  // ← 遅れてセットされる
+}
+```
+
+**症状:** `Cmd+Shift+Space` を素早く2回押すと、1回目の `isActive = true` がセットされる前に2回目の `activate()` がガードを通過する。その結果、`fetchClickableElements` が2回実行され、`startHintMode` が2回呼ばれて `HintView` が2重に追加される（状態破壊）。
+
+### 修正方針
+
+`isActive` フラグを廃止し、`state` 列挙型に `.fetching`（要素取得中）状態を追加する。`activate()` の先頭で `state = .fetching` を**同期的に**セットすることで、次の `activate()` 呼び出しをブロックできる。これにより「状態は常に `state` 一本で管理する」という原則も守られる。
+
+### 修正後のコード
+
+```swift
+// HintModeController.swift
+
+private enum HintModeState {
+    case inactive
+    case fetching   // 追加: 要素取得中。この状態でも activate() を弾く
+    case active(hints: [UIElementInfo], input: String)
+}
+
+@MainActor
+final class HintModeController {
+    private var state: HintModeState = .inactive
+    // isActive: Bool は削除
+
+    func activate(overlayWindow: OverlayWindow, hotkeyManager: HotkeyManager) {
+        guard case .inactive = state else { return }  // fetching / active 中はスキップ
+        state = .fetching                              // 同期的に状態変更（二重起動防止）
+
+        // ...（非同期取得は変更なし）
+        axManager.fetchClickableElements(in: appElement) { [weak self] elements in
+            Task { @MainActor [weak self] in
+                self?.startHintMode(elements: elements, ...)
+            }
+        }
+    }
+
+    private func startHintMode(elements: [AXElement], ...) {
+        guard !elements.isEmpty else {
+            state = .inactive  // 要素がなければ inactive に戻す
+            return
+        }
+        // ...
+        state = .active(hints: hints, input: "")
+        // isActive = true は不要（削除）
+    }
+
+    func deactivate() {
+        state = .inactive
+        // isActive = false は不要（削除）
+        // ...（他は変更なし）
+    }
+}
+```
+
+---
+
+## Phase 4: HotkeyManager のスレッド安全性
+
+### 現状の問題
+
+`keyEventHandler` は CGEventTap スレッドから**読まれ**、メインスレッドから**書かれる**変数である。
+
+```swift
+// HotkeyManager.swift（現状）
+final class HotkeyManager: @unchecked Sendable {
+    var keyEventHandler: ((CGKeyCode, CGEventFlags) -> Bool)?  // ← 同期機構なし
+
+    // CGEventTap スレッドから呼ばれる
+    private func handleEvent(...) {
+        if let handler = keyEventHandler, handler(keyCode, flags) { ... }  // 読み取り
+    }
+}
+
+// AppDelegate.swift（メインスレッド）
+hotkeyManager.keyEventHandler = { ... }  // 書き込み
+```
+
+2つのスレッドが同期なしで同じ変数を読み書きしているため、データレースが存在する。Swift 6 では `@unchecked Sendable` でコンパイルエラーは回避できるが、実行時のデータレースは残ったままである。現状は問題が顕在化しにくいが、理論上は未定義動作（クラッシュや不正な状態読み取り）を引き起こしうる。
+
+### 修正方針
+
+`NSLock` を使って `keyEventHandler` へのアクセスをラップする。`NSLock` は CGEventTap スレッドとメインスレッドの両方から安全に使える。
+
+computed property として `keyEventHandler` を公開し、内部では `_keyEventHandler` をロック付きで読み書きする。利用側（`AppDelegate`・各 Controller）のコードは変更不要。
+
+### 修正後のコード
+
+```swift
+// HotkeyManager.swift
+
+final class HotkeyManager: @unchecked Sendable {
+    private let handlerLock = NSLock()
+    private var _keyEventHandler: ((CGKeyCode, CGEventFlags) -> Bool)?
+
+    // 外部からは従来どおり keyEventHandler として読み書きできる
+    var keyEventHandler: ((CGKeyCode, CGEventFlags) -> Bool)? {
+        get {
+            handlerLock.lock()
+            defer { handlerLock.unlock() }
+            return _keyEventHandler
+        }
+        set {
+            handlerLock.lock()
+            defer { handlerLock.unlock() }
+            _keyEventHandler = newValue
+        }
+    }
+
+    // handleEvent / start / onHintModeActivated 等は変更なし
+}
+```
+
+---
+
+## Phase 5: UIElementEnumerator のパフォーマンス最適化
+
+### 現状の問題
+
+`isClickable` は全要素に対して最大3回の AX IPC 呼び出しを行う。IPC はプロセス間通信であり、呼び出しコストが高い。
+
+```
+現状の呼び出し順（全要素）:
+1. AXUIElementCopyAttributeValue(AXEnabled)   ← IPC
+2. AXUIElementCopyActionNames                 ← IPC（最も重い）
+3. AXUIElementCopyAttributeValue(AXRole)      ← IPC（フォールバック）
+4. AXUIElementCopyAttributeValue(AXChildren)  ← IPC
+
+× 深さ50 × 要素数 → 数千回のプロセス間通信
+```
+
+### 最適化1: ロールチェックを先頭に移動 + skip-list 導入
+
+ほとんどの要素は `AXStaticText`・`AXImage`・`AXSeparator` 等の確定的に非クリックなロールを持つ。
+これらを1回の IPC（AXRole）だけで弾くことで、後続の高コスト呼び出しをスキップできる。
+
+```
+最適化後:
+  skip-list 該当 → AXRole のみ              = 1 IPC（節約: 2）
+  clickableRoles 該当 → AXRole + AXEnabled  = 2 IPC（節約: 1）
+  不明ロール → AXRole + AXEnabled + AXPress = 3 IPC（変化なし）
+```
+
+### 最適化2: 深さ上限を 50 → 25 に削減
+
+50 に上げた理由は Electron 対応だったが、調査の結果：
+- Chrome の有効な要素（タブ・ツールバー）は深さ10以下に存在
+- Obsidian のフォルダ要素は AXPress を持たず、深さに関わらず検出不能
+
+深さ50は無駄なトラバーサルになっている。25 でほぼ全ての実用ケースをカバーできる。
+
+### 修正後のコード
+
+```swift
+// UIElementEnumerator.swift
+private static let skippableRoles: Set<String> = [
+    "AXStaticText", "AXImage", "AXSeparator", "AXScrollBar",
+    "AXScrollArea", "AXSplitter", "AXToolbar", "AXStatusBar",
+    "AXTable", "AXOutline", "AXList", "AXBrowser"
+]
+
+private static func isClickable(element: AXUIElement) -> Bool {
+    // ロールを先に確認（AXPress より安価な IPC）
+    var roleRef: CFTypeRef?
+    if AXUIElementCopyAttributeValue(element, "AXRole" as CFString, &roleRef) == .success,
+       let role = roleRef as? String {
+        if skippableRoles.contains(role) { return false }        // 確定的に非クリック
+        if clickableRoles.contains(role) { return isEnabled(element: element) }  // 確定的にクリック可
+    }
+    // 不明ロール → AXPress でチェック（Electron 対応）
+    guard isEnabled(element: element) else { return false }
+    var actionsRef: CFArray?
+    guard AXUIElementCopyActionNames(element, &actionsRef) == .success,
+          let actions = actionsRef as? [String] else { return false }
+    return actions.contains("AXPress")
+}
+
+// 深さ上限: 50 → 25
+guard depth < 25 else { return }
+```
+
+---
+
+## Phase 6: コンテナ要素のスキップ（Chrome 検索結果クリック改善）
+
+### 現状の問題
+
+Chrome のウェブコンテンツは階層的な AX ツリーを持つ。Google 検索結果の場合：
+
+```
+AXGroup（検索結果カード全体、JS onclick 付き）→ AXPress あり
+  └── AXLink（タイトル <a> タグ）→ AXPress あり
+```
+
+現在の `collectClickable` は **両方** を検出する。結果として：
+- `AXGroup`（カード全体）のヒントが表示 → ラベル例「fa」
+- `AXLink`（タイトル部分）にも別のヒントが表示 → ラベル例「fb」
+
+ユーザーが「fa」（`AXGroup` のラベル）を選択すると：
+- `AXPress` on `AXGroup` → JS onclick 発火、ナビゲートしない or 挙動不定
+- `clickAt(center)` フォールバック → カードの中心をクリック → タイトルリンクは上部にあるためヒット不可
+
+### 修正方針
+
+`collectClickable` を変更し、**クリック可能な直接の子を持つ要素はスキップ**する（リーフレベルのインタラクティブ要素を優先）。
+
+- `AXGroup`（子に `AXLink` を持つ）→ スキップ
+- `AXLink`（子にクリック可能なものがない）→ 追加
+
+`AXLink` に対して `AXPress` を実行すると Chrome は正しくナビゲートする。
+
+### 修正後のコード
+
+```swift
+// UIElementEnumerator.swift — collectClickable
+private static func collectClickable(
+    element: AXUIElement,
+    into result: inout [AXUIElement],
+    depth: Int
+) {
+    guard depth < 25 else { return }
+
+    var childrenRef: CFTypeRef?
+    let err = AXUIElementCopyAttributeValue(element, "AXChildren" as CFString, &childrenRef)
+    let children = (err == .success ? childrenRef as? [AXUIElement] : nil) ?? []
+
+    if isClickable(element: element) {
+        // クリック可能な直接の子を持つコンテナはスキップ（リーフ要素を優先）
+        let hasClickableChild = children.contains { isClickable(element: $0) }
+        if !hasClickableChild {
+            result.append(element)
+        }
+    }
+
+    for child in children {
+        collectClickable(element: child, into: &result, depth: depth + 1)
+    }
+}
+```
+
+**トレードオフ:** 直接の子のみチェックするため、クリック可能な孫がいる場合は中間の `AXGroup` が除外されず残ることがある。ただし Google 検索結果のような一般的な構造（外側コンテナ → 直接の子リンク）には有効。
+
+---
+
+## テスト
+
+### LabelGeneratorTests.swift（既存ファイルを更新）
+
+追加するテストケース（Swift Testing 形式）:
+
+```swift
+// prefix-free: 1文字ラベルと2文字ラベルが混在しないこと
+@Test func testNoMixedLengthLabels() {
+    let labels = LabelGenerator.generateLabels(count: 20)
+    let lengths = Set(labels.map { $0.count })
+    #expect(lengths.count == 1, "全ラベルが同じ長さであること")
+}
+
+// セミコロンが含まれないこと
+@Test func testNoSemicolon() {
+    let labels = LabelGenerator.generateLabels(count: 256)
+    #expect(!labels.contains { $0.contains(";") })
+}
+
+// 16個以下は1文字ラベル
+@Test func testSingleCharLabelsForSmallCount() {
+    let labels = LabelGenerator.generateLabels(count: 16)
+    #expect(labels.allSatisfy { $0.count == 1 })
+}
+
+// 17個以上は2文字ラベル
+@Test func testDoubleCharLabelsForLargeCount() {
+    let labels = LabelGenerator.generateLabels(count: 17)
+    #expect(labels.allSatisfy { $0.count == 2 })
+}
+
+// ラベルに重複がないこと
+@Test func testLabelsAreUnique() {
+    let labels = LabelGenerator.generateLabels(count: 100)
+    #expect(Set(labels).count == labels.count)
+}
+```
+
+**注意:** `UIElementEnumerator` / `HintModeController` / `HotkeyManager` の修正は AXUIElement・CGEventTap 依存が強く、現時点ではモック化が困難なため手動動作確認で代替する。
+
+---
+
+## 技術的注意点
+
+### LabelGenerator の最大容量
+
+`chars` は16文字 → 2文字ラベルの最大は `16 × 16 = 256`。ほとんどのアプリで十分だが、非常にリッチな UI（256要素超）では対応しきれない。現時点では既知の制約として許容する。
+
+### Obsidian ファイルエクスプローラーは対応不可（既知の制約）
+
+Obsidian のファイルエクスプローラー（フォルダ・ファイル一覧）は AX API に意味のある形で露出していない。
+AX ツリー調査の結果：
+- `AXWebArea` 配下の全要素は `[AXShowMenu, AXScrollToVisible]` のみ（`AXPress` なし）
+- フォルダ項目は `AXGroup title=""` として存在するが識別可能な属性を持たない
+- Obsidian 側が accessibility セマンティクスを実装していないため、どのアプローチでも検出不可能
+
+Chrome の native UI（タブ・アドレスバー等）や macOS の window ボタンは引き続き検出・クリック可能。
+
+### AXPress アクションによる副作用
+
+ロールベースより多くの要素を拾う可能性がある（例: 不可視の AXPress 要素）。`AXEnabled` チェックが緩和策になるが完全ではない。また `AXUIElementCopyActionNames` は `AXUIElementCopyAttributeValue` より若干コストが高いため、要素数が多いアプリでのパフォーマンスを手動確認すること。
+
+### `.fetching` 状態の間のキー入力
+
+`state = .fetching` の間は `keyEventHandler` がセットされていないため、キー入力はすべて元のアプリに素通りする。これは意図した挙動（フェッチ中に誤操作しない）。
+
+---
+
+## 実装チェックリスト
+
+```
+[ ] Phase 1-1: LabelGenerator — `;` を `p` に変更（chars 文字列の更新）
+[ ] Phase 1-2: LabelGenerator — generateLabels を prefix-free ロジックに書き換え
+[ ] Phase 1 テスト: LabelGeneratorTests.swift に5件のテスト追加・全テストパス
+
+[x] Phase 2-1: UIElementEnumerator — isClickable をアクションベース（AXPress）に変更
+[x] Phase 2-2: UIElementEnumerator — isEnabled チェック追加
+[x] Phase 2-3: UIElementEnumerator — clickableRoles を削除
+[x] Phase 2-4: UIElementEnumerator — 深さ上限 20 → 50 に変更
+
+[ ] Phase 2.1-1: HintModeController — click(element:) → clickAt(frame:) に変更
+[ ] Phase 2.1-2: UIElementEnumerator — clickableRoles フォールバック追加（ハイブリッド検出）
+
+[ ] Phase 3-1: HintModeController — HintModeState に .fetching 追加
+[ ] Phase 3-2: HintModeController — isActive プロパティ削除
+[ ] Phase 3-3: HintModeController — activate() のガードを state ベース（guard case .inactive）に変更
+[ ] Phase 3-4: HintModeController — startHintMode() で空要素時に state = .inactive に戻す
+[ ] Phase 3-5: HintModeController — deactivate() から isActive = false を削除
+
+[x] Phase 4-1: HotkeyManager — handlerLock (NSLock) プロパティ追加
+[x] Phase 4-2: HotkeyManager — _keyEventHandler をバッキングストアに変更
+[x] Phase 4-3: HotkeyManager — keyEventHandler を computed property（ロック付き）に変更
+
+[x] Phase 5-1: UIElementEnumerator — skippableRoles 追加
+[x] Phase 5-2: UIElementEnumerator — isClickable をロール先頭チェックに変更
+[x] Phase 5-3: UIElementEnumerator — 深さ上限 50 → 25 に変更
+[~] Phase 5-4: 高さ 100px フィルタは不採用（ヒューリスティックで危険）→ Phase 6 で根本対応
+
+[ ] Phase 6-1: UIElementEnumerator — collectClickable でクリック可能な直接の子を持つ要素をスキップ（保留中: Chrome 検索結果での効果未確認）
+
+[ ] swift build 成功
+[ ] swift test 全テストパス
+[ ] 手動確認: 16要素以下のアプリで1文字ラベルが出る
+[ ] 手動確認: 17要素以上のアプリで2文字ラベルが出て正しく選択できる
+[ ] 手動確認: Chrome / Obsidian でヒントが表示される（改善確認）
+[ ] 手動確認: Cmd+Shift+Space の連打で状態が壊れない
+[ ] 手動確認: 無効ボタンにヒントが表示されない
+```


### PR DESCRIPTION
## Summary

- **LabelGenerator**: `;` を `p` に変更、prefix-free ロジックに書き換え（16要素以下は1文字、超えたら2文字 → 2文字ラベル選択不能バグ解消）
- **UIElementEnumerator**: AXPress ベース検出に変更（Electron/Chrome 対応）、AXEnabled チェック追加、skippableRoles で IPC 呼び出し最小化、深さ上限 20→25
- **HintModeController**: `.fetching` 状態追加で `Cmd+Shift+Space` 連打による二重起動防止、クリックを `clickAt(frame:)` に統一
- **HotkeyManager**: NSLock で `keyEventHandler` をスレッドセーフ化（CGEventTap スレッド vs メインスレッドのデータレース解消）
- **LabelGeneratorTests**: prefix-free・`;` なし・一意性の検証テスト追加

## Known limitations

- Chrome 検索結果のような「コンテナ + 子リンク」構造では、コンテナと子リンクの両方にヒントが表示される場合がある（未解決・保留中）

## Test plan

- [ ] 16要素以下のアプリで1文字ラベルが表示される
- [ ] 17要素以上のアプリで2文字ラベルが正しく選択・クリックできる
- [ ] Chrome でヒント表示・クリックが動作する
- [ ] `Cmd+Shift+Space` 連打で状態が壊れない
- [ ] 無効ボタン（グレーアウト）にヒントが表示されない
- [ ] `swift test` 全テストパス（29/29）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Closes #15