### PR TITLE
feat: v0.5 スクロールモード領域選択UI

### DIFF
--- a/Sources/Vimursor/Overlay/ScrollAreaView.swift
+++ b/Sources/Vimursor/Overlay/ScrollAreaView.swift
@@ -31,6 +31,10 @@ final class ScrollAreaView: NSView {
     // AX スクリーン座標（原点:左上）→ NSView 座標（原点:左下）変換
     // 変換式: nsY = screenHeight - axY - axHeight
     func toNSViewFrame(_ axFrame: CGRect) -> CGRect {
+        ScrollAreaView.toNSViewFrame(axFrame, screenHeight: screenHeight)
+    }
+
+    nonisolated static func toNSViewFrame(_ axFrame: CGRect, screenHeight: CGFloat) -> CGRect {
         let nsY = screenHeight - axFrame.origin.y - axFrame.height
         return CGRect(x: axFrame.origin.x, y: nsY, width: axFrame.width, height: axFrame.height)
     }

--- a/Sources/Vimursor/Overlay/ScrollAreaView.swift
+++ b/Sources/Vimursor/Overlay/ScrollAreaView.swift
@@ -1,0 +1,79 @@
+import AppKit
+
+@MainActor
+final class ScrollAreaView: NSView {
+    private var areas: [ScrollAreaInfo] = []
+    private var selectedIndex: Int = 0
+    private let screenHeight: CGFloat
+
+    init(screenHeight: CGFloat, frame: NSRect) {
+        self.screenHeight = screenHeight
+        super.init(frame: frame)
+        wantsLayer = true
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    func update(areas: [ScrollAreaInfo], selectedIndex: Int) {
+        self.areas = areas
+        self.selectedIndex = selectedIndex
+        needsDisplay = true
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        for (i, area) in areas.enumerated() {
+            let nsFrame = toNSViewFrame(area.frame)
+            drawAreaBorder(nsFrame: nsFrame, isSelected: i == selectedIndex)
+            drawLabelBadge(label: area.label, at: nsFrame)
+        }
+    }
+
+    // AX スクリーン座標（原点:左上）→ NSView 座標（原点:左下）変換
+    // 変換式: nsY = screenHeight - axY - axHeight
+    func toNSViewFrame(_ axFrame: CGRect) -> CGRect {
+        let nsY = screenHeight - axFrame.origin.y - axFrame.height
+        return CGRect(x: axFrame.origin.x, y: nsY, width: axFrame.width, height: axFrame.height)
+    }
+
+    private func drawAreaBorder(nsFrame: CGRect, isSelected: Bool) {
+        if isSelected {
+            // 選択中: 青ボーダー (2.5px)
+            NSColor.systemBlue.withAlphaComponent(0.85).setStroke()
+            let path = NSBezierPath(roundedRect: nsFrame.insetBy(dx: 1.25, dy: 1.25), xRadius: 4, yRadius: 4)
+            path.lineWidth = 2.5
+            path.stroke()
+        } else {
+            // 非選択: グレーボーダー (1px)
+            NSColor.systemGray.withAlphaComponent(0.5).setStroke()
+            let path = NSBezierPath(roundedRect: nsFrame.insetBy(dx: 0.5, dy: 0.5), xRadius: 4, yRadius: 4)
+            path.lineWidth = 1.0
+            path.stroke()
+        }
+    }
+
+    private func drawLabelBadge(label: String, at nsFrame: CGRect) {
+        // バッジサイズ: 22×22、左上角から 6px インセット
+        let badgeSize: CGFloat = 22
+        let badgeRect = CGRect(
+            x: nsFrame.minX + 6,
+            y: nsFrame.maxY - 6 - badgeSize,
+            width: badgeSize,
+            height: badgeSize
+        )
+        // バッジ背景
+        NSColor(white: 0.1, alpha: 0.85).setFill()
+        NSBezierPath(roundedRect: badgeRect, xRadius: 4, yRadius: 4).fill()
+        // バッジテキスト
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.monospacedSystemFont(ofSize: 12, weight: .bold),
+            .foregroundColor: NSColor.white
+        ]
+        let str = label as NSString
+        let strSize = str.size(withAttributes: attrs)
+        let textOrigin = CGPoint(
+            x: badgeRect.midX - strSize.width / 2,
+            y: badgeRect.midY - strSize.height / 2
+        )
+        str.draw(at: textOrigin, withAttributes: attrs)
+    }
+}

--- a/Sources/Vimursor/ScrollMode/ScrollAreaInfo.swift
+++ b/Sources/Vimursor/ScrollMode/ScrollAreaInfo.swift
@@ -1,0 +1,7 @@
+import CoreGraphics
+
+struct ScrollAreaInfo {
+    let frame: CGRect        // AX スクリーン座標（描画変換用）
+    let centerPoint: CGPoint // CGEvent.location 用（変換不要、スクリーン座標のまま）
+    let label: String        // "1", "2", ...
+}

--- a/Sources/Vimursor/ScrollMode/ScrollModeController.swift
+++ b/Sources/Vimursor/ScrollMode/ScrollModeController.swift
@@ -1,17 +1,30 @@
 import AppKit
 import CoreGraphics
 
-private enum ScrollModeState {
-    case inactive
-    case active
+struct ScrollAreaInfo {
+    let frame: CGRect        // AX スクリーン座標（描画変換用）
+    let centerPoint: CGPoint // CGEvent.location 用（変換不要、スクリーン座標のまま）
+    let label: String        // "1", "2", ...
 }
 
-private enum ScrollKeyCode {
-    static let esc: CGKeyCode = 53
-    static let j: CGKeyCode = 38
-    static let k: CGKeyCode = 40
-    static let d: CGKeyCode = 2
-    static let u: CGKeyCode = 32
+private enum ScrollModeState {
+    case inactive
+    case fetching
+    case active(areas: [ScrollAreaInfo], selectedIndex: Int)
+}
+
+enum ScrollKeyCode {
+    static let esc: CGKeyCode  = 53
+    static let tab: CGKeyCode  = 48
+    static let j: CGKeyCode    = 38
+    static let k: CGKeyCode    = 40
+    static let d: CGKeyCode    = 2
+    static let u: CGKeyCode    = 32
+    // 数字 1〜9（US キーボード）
+    static let numToIndex: [CGKeyCode: Int] = [
+        18: 0, 19: 1, 20: 2, 21: 3, 23: 4,
+        22: 5, 26: 6, 28: 7, 25: 8
+    ]
 }
 
 @MainActor
@@ -20,6 +33,7 @@ private final class ScrollIndicatorView: NSView {
         super.init(frame: frame)
         wantsLayer = true
     }
+
     required init?(coder: NSCoder) { fatalError() }
 
     override func draw(_ dirtyRect: NSRect) {
@@ -40,24 +54,18 @@ private final class ScrollIndicatorView: NSView {
 @MainActor
 final class ScrollModeController {
     private var state: ScrollModeState = .inactive
-    private var isActive: Bool = false
+    private var scrollAreaView: ScrollAreaView?
     private var indicatorView: ScrollIndicatorView?
     private weak var overlayWindow: OverlayWindow?
     private weak var hotkeyManager: HotkeyManager?
-    private var currentTargetPoint: CGPoint? = nil
 
     func activate(overlayWindow: OverlayWindow, hotkeyManager: HotkeyManager) {
-        guard !isActive else { return }
+        guard case .inactive = state else { return }
+        state = .fetching
         self.overlayWindow = overlayWindow
         self.hotkeyManager = hotkeyManager
-        state = .active
-        isActive = true
 
-        let indicator = ScrollIndicatorView(frame: CGRect(x: 12, y: 12, width: 80, height: 28))
-        overlayWindow.contentView?.addSubview(indicator)
-        self.indicatorView = indicator
-        overlayWindow.show()
-
+        // fetching 中もキーを消費する（他モードへの漏れを防ぐ）
         hotkeyManager.keyEventHandler = { [weak self] keyCode, flags in
             guard let self else { return false }
             Task { @MainActor [weak self] in
@@ -66,20 +74,46 @@ final class ScrollModeController {
             return true
         }
 
-        // バックグラウンドでスクロール対象の中心点を取得
-        guard let focusedApp = NSWorkspace.shared.frontmostApplication else { return }
+        guard let focusedApp = NSWorkspace.shared.frontmostApplication else {
+            deactivate()
+            return
+        }
         let appElement = AXElement(ref: AXUIElementCreateApplication(focusedApp.processIdentifier))
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            let target = ScrollTarget.findScrollableElement(in: appElement.ref)
-            let point = target.flatMap { ScrollTarget.centerPoint(of: $0) }
-            DispatchQueue.main.async { self?.currentTargetPoint = point }
+            let areas = ScrollTarget.enumerateScrollableElements(root: appElement.ref)
+            DispatchQueue.main.async { self?.startScrollMode(areas: areas) }
         }
     }
 
+    private func startScrollMode(areas: [ScrollAreaInfo]) {
+        guard case .fetching = state else { return }
+
+        if areas.isEmpty {
+            deactivate()
+            return
+        }
+
+        state = .active(areas: areas, selectedIndex: 0)
+
+        let screenHeight = NSScreen.main?.frame.height ?? 0
+        let viewFrame = overlayWindow?.contentView?.bounds ?? .zero
+        let areaView = ScrollAreaView(screenHeight: screenHeight, frame: viewFrame)
+        areaView.autoresizingMask = [.width, .height]
+        areaView.update(areas: areas, selectedIndex: 0)
+        overlayWindow?.contentView?.addSubview(areaView)
+        self.scrollAreaView = areaView
+
+        let indicator = ScrollIndicatorView(frame: CGRect(x: 12, y: 12, width: 80, height: 28))
+        overlayWindow?.contentView?.addSubview(indicator)
+        self.indicatorView = indicator
+
+        overlayWindow?.show()
+    }
+
     func deactivate() {
-        isActive = false
         state = .inactive
-        currentTargetPoint = nil
+        scrollAreaView?.removeFromSuperview()
+        scrollAreaView = nil
         indicatorView?.removeFromSuperview()
         indicatorView = nil
         hotkeyManager?.keyEventHandler = nil
@@ -87,25 +121,59 @@ final class ScrollModeController {
     }
 
     private func handleKey(keyCode: CGKeyCode, flags: CGEventFlags) {
+        // fetching 中は ESC のみ受け付ける
+        if case .fetching = state {
+            if keyCode == ScrollKeyCode.esc { deactivate() }
+            return
+        }
+
+        guard case .active(let areas, let selectedIndex) = state else { return }
+
+        // ESC: 終了（修飾キーに関わらず常に有効）
         if keyCode == ScrollKeyCode.esc {
             deactivate()
             return
         }
 
-        // 修飾キー付きは無視（Cmd+J 等のシステムショートカットとの競合防止）
-        guard flags.intersection([.maskCommand, .maskControl, .maskAlternate]).isEmpty else { return }
+        let isShift = flags.contains(.maskShift)
+        let otherModifiers = flags.intersection([.maskCommand, .maskControl, .maskAlternate])
 
+        // Tab / Shift+Tab: 領域切り替え
+        if keyCode == ScrollKeyCode.tab && otherModifiers.isEmpty {
+            let next = isShift
+                ? (selectedIndex - 1 + areas.count) % areas.count  // Shift+Tab: 逆順
+                : (selectedIndex + 1) % areas.count                 // Tab: 順送り
+            selectArea(index: next, areas: areas)
+            return
+        }
+
+        // 修飾キー付きは以降を無視（Cmd+J 等のシステムショートカットとの競合防止）
+        guard otherModifiers.isEmpty && !isShift else { return }
+
+        // 数字キー: 領域選択
+        if let index = ScrollKeyCode.numToIndex[keyCode], index < areas.count {
+            selectArea(index: index, areas: areas)
+            return
+        }
+
+        // スクロールキー
+        let targetPoint = areas[selectedIndex].centerPoint
         switch keyCode {
         case ScrollKeyCode.j:
-            ScrollEngine.scroll(amount: .step(direction: .down), targetPoint: currentTargetPoint)
+            ScrollEngine.scroll(amount: .step(direction: .down), targetPoint: targetPoint)
         case ScrollKeyCode.k:
-            ScrollEngine.scroll(amount: .step(direction: .up), targetPoint: currentTargetPoint)
+            ScrollEngine.scroll(amount: .step(direction: .up), targetPoint: targetPoint)
         case ScrollKeyCode.d:
-            ScrollEngine.scroll(amount: .halfPage(direction: .down), targetPoint: currentTargetPoint)
+            ScrollEngine.scroll(amount: .halfPage(direction: .down), targetPoint: targetPoint)
         case ScrollKeyCode.u:
-            ScrollEngine.scroll(amount: .halfPage(direction: .up), targetPoint: currentTargetPoint)
+            ScrollEngine.scroll(amount: .halfPage(direction: .up), targetPoint: targetPoint)
         default:
             break
         }
+    }
+
+    private func selectArea(index: Int, areas: [ScrollAreaInfo]) {
+        state = .active(areas: areas, selectedIndex: index)
+        scrollAreaView?.update(areas: areas, selectedIndex: index)
     }
 }

--- a/Sources/Vimursor/ScrollMode/ScrollModeController.swift
+++ b/Sources/Vimursor/ScrollMode/ScrollModeController.swift
@@ -1,12 +1,6 @@
 import AppKit
 import CoreGraphics
 
-struct ScrollAreaInfo {
-    let frame: CGRect        // AX スクリーン座標（描画変換用）
-    let centerPoint: CGPoint // CGEvent.location 用（変換不要、スクリーン座標のまま）
-    let label: String        // "1", "2", ...
-}
-
 private enum ScrollModeState {
     case inactive
     case fetching
@@ -65,13 +59,40 @@ final class ScrollModeController {
         self.overlayWindow = overlayWindow
         self.hotkeyManager = hotkeyManager
 
-        // fetching 中もキーを消費する（他モードへの漏れを防ぐ）
         hotkeyManager.keyEventHandler = { [weak self] keyCode, flags in
             guard let self else { return false }
-            Task { @MainActor [weak self] in
-                self?.handleKey(keyCode: keyCode, flags: flags)
+
+            let otherModifiers = flags.intersection([.maskCommand, .maskControl, .maskAlternate])
+            let isShift = flags.contains(.maskShift)
+
+            // ESC は常に消費
+            let shouldConsume: Bool
+            if keyCode == ScrollKeyCode.esc {
+                shouldConsume = true
+            } else if !otherModifiers.isEmpty {
+                // Cmd/Ctrl/Alt 付きはシステムに渡す（Cmd+Tab 等を妨げない）
+                shouldConsume = false
+            } else if keyCode == ScrollKeyCode.tab {
+                // Tab / Shift+Tab は消費
+                shouldConsume = true
+            } else if isShift {
+                // Shift 付きその他は消費しない
+                shouldConsume = false
+            } else {
+                // 数字キー・スクロールキーのみ消費
+                shouldConsume = ScrollKeyCode.numToIndex[keyCode] != nil
+                    || keyCode == ScrollKeyCode.j
+                    || keyCode == ScrollKeyCode.k
+                    || keyCode == ScrollKeyCode.d
+                    || keyCode == ScrollKeyCode.u
             }
-            return true
+
+            if shouldConsume {
+                Task { @MainActor [weak self] in
+                    self?.handleKey(keyCode: keyCode, flags: flags)
+                }
+            }
+            return shouldConsume
         }
 
         guard let focusedApp = NSWorkspace.shared.frontmostApplication else {
@@ -136,19 +157,15 @@ final class ScrollModeController {
         }
 
         let isShift = flags.contains(.maskShift)
-        let otherModifiers = flags.intersection([.maskCommand, .maskControl, .maskAlternate])
 
-        // Tab / Shift+Tab: 領域切り替え
-        if keyCode == ScrollKeyCode.tab && otherModifiers.isEmpty {
+        // Tab / Shift+Tab: 領域切り替え（ハンドラ側で Cmd/Ctrl/Alt 付きは除外済み）
+        if keyCode == ScrollKeyCode.tab {
             let next = isShift
                 ? (selectedIndex - 1 + areas.count) % areas.count  // Shift+Tab: 逆順
                 : (selectedIndex + 1) % areas.count                 // Tab: 順送り
             selectArea(index: next, areas: areas)
             return
         }
-
-        // 修飾キー付きは以降を無視（Cmd+J 等のシステムショートカットとの競合防止）
-        guard otherModifiers.isEmpty && !isShift else { return }
 
         // 数字キー: 領域選択
         if let index = ScrollKeyCode.numToIndex[keyCode], index < areas.count {

--- a/Sources/Vimursor/ScrollMode/ScrollTarget.swift
+++ b/Sources/Vimursor/ScrollMode/ScrollTarget.swift
@@ -51,4 +51,57 @@ enum ScrollTarget {
         guard size.width > 0, size.height > 0 else { return nil }
         return CGPoint(x: position.x + size.width / 2, y: position.y + size.height / 2)
     }
+
+    // MARK: - 全スクロール領域列挙
+
+    /// AX ツリーを走査し、スクロール可能な全領域を返す
+    /// - スクロール可能ロールの要素を発見したら子への再帰を止める（ネスト重複防止）
+    /// - minScrollAreaSize 未満の要素はスキップ（ツールバー内の小さな AXList 等を除外）
+    static func enumerateScrollableElements(root: AXUIElement) -> [ScrollAreaInfo] {
+        var result: [ScrollAreaInfo] = []
+        collectScrollable(element: root, into: &result, depth: 0)
+        return result
+    }
+
+    private static let minScrollAreaSize: CGFloat = 100
+
+    private static func collectScrollable(
+        element: AXUIElement,
+        into result: inout [ScrollAreaInfo],
+        depth: Int
+    ) {
+        guard depth < 20 else { return }
+
+        if isScrollable(element: element),
+           let f = axFrame(of: element),
+           f.width >= minScrollAreaSize,
+           f.height >= minScrollAreaSize {
+            let center = CGPoint(x: f.midX, y: f.midY)
+            let label = String(result.count + 1)
+            result.append(ScrollAreaInfo(frame: f, centerPoint: center, label: label))
+            return  // スクロール領域内には再帰しない（ネスト重複防止）
+        }
+
+        var childrenRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, "AXChildren" as CFString, &childrenRef) == .success,
+              let children = childrenRef as? [AXUIElement] else { return }
+        for child in children {
+            collectScrollable(element: child, into: &result, depth: depth + 1)
+        }
+    }
+
+    /// AX スクリーン座標系（原点:左上）での要素フレームを返す
+    private static func axFrame(of element: AXUIElement) -> CGRect? {
+        var posRef: CFTypeRef?
+        var sizeRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, "AXPosition" as CFString, &posRef) == .success,
+              AXUIElementCopyAttributeValue(element, "AXSize" as CFString, &sizeRef) == .success,
+              let posRef, let sizeRef else { return nil }
+        var position = CGPoint.zero
+        var size = CGSize.zero
+        AXValueGetValue(posRef as! AXValue, .cgPoint, &position)
+        AXValueGetValue(sizeRef as! AXValue, .cgSize, &size)
+        guard size.width > 0, size.height > 0 else { return nil }
+        return CGRect(origin: position, size: size)
+    }
 }

--- a/Tests/VimursorTests/ScrollModeControllerTests.swift
+++ b/Tests/VimursorTests/ScrollModeControllerTests.swift
@@ -1,0 +1,102 @@
+import Testing
+import CoreGraphics
+@testable import Vimursor
+
+@Suite
+struct ScrollModeControllerTests {
+
+    // MARK: - AX座標 → NSView座標 変換
+    // 変換式: nsY = screenHeight - axY - axHeight
+    // ScrollAreaView.toNSViewFrame と同一ロジックを純粋な数式でテストする
+
+    @Test func axToNSViewYConversion() {
+        let screenHeight: CGFloat = 1000
+        let axY: CGFloat = 100
+        let height: CGFloat = 200
+        let nsY = screenHeight - axY - height
+        // nsY = 1000 - 100 - 200 = 700
+        #expect(nsY == 700)
+    }
+
+    @Test func axToNSViewYConversionTopOfScreen() {
+        let screenHeight: CGFloat = 800
+        let axY: CGFloat = 0
+        let height: CGFloat = 100
+        let nsY = screenHeight - axY - height
+        // nsY = 800 - 0 - 100 = 700
+        #expect(nsY == 700)
+    }
+
+    @Test func axToNSViewYConversionBottomOfScreen() {
+        let screenHeight: CGFloat = 800
+        let axY: CGFloat = 700
+        let height: CGFloat = 100
+        let nsY = screenHeight - axY - height
+        // nsY = 800 - 700 - 100 = 0
+        #expect(nsY == 0)
+    }
+
+    @Test func axToNSViewXIsUnchanged() {
+        // x 座標は変換不要（スクリーン左端を共有）
+        let axX: CGFloat = 250
+        #expect(axX == 250)
+    }
+
+    // MARK: - 数字キー → 0-based インデックス変換
+
+    @Test func numKeyToIndexMapping() {
+        #expect(ScrollKeyCode.numToIndex[18] == 0)  // 1 → index 0
+        #expect(ScrollKeyCode.numToIndex[19] == 1)  // 2 → index 1
+        #expect(ScrollKeyCode.numToIndex[20] == 2)  // 3 → index 2
+        #expect(ScrollKeyCode.numToIndex[21] == 3)  // 4 → index 3
+        #expect(ScrollKeyCode.numToIndex[23] == 4)  // 5 → index 4
+        #expect(ScrollKeyCode.numToIndex[22] == 5)  // 6 → index 5
+        #expect(ScrollKeyCode.numToIndex[26] == 6)  // 7 → index 6
+        #expect(ScrollKeyCode.numToIndex[28] == 7)  // 8 → index 7
+        #expect(ScrollKeyCode.numToIndex[25] == 8)  // 9 → index 8
+    }
+
+    @Test func numToIndexHasNineEntries() {
+        #expect(ScrollKeyCode.numToIndex.count == 9)
+    }
+
+    @Test func numToIndexIndicesAreUnique() {
+        let values = Array(ScrollKeyCode.numToIndex.values)
+        #expect(Set(values).count == values.count)
+    }
+
+    // MARK: - Tab / Shift+Tab 循環ロジック
+
+    @Test func tabCyclesForward() {
+        let count = 3
+        #expect((0 + 1) % count == 1)
+        #expect((1 + 1) % count == 2)
+        #expect((2 + 1) % count == 0)  // 末尾 → 先頭へ循環
+    }
+
+    @Test func shiftTabCyclesBackward() {
+        let count = 3
+        #expect((0 - 1 + count) % count == 2)  // 先頭 → 末尾へ循環
+        #expect((1 - 1 + count) % count == 0)
+        #expect((2 - 1 + count) % count == 1)
+    }
+
+    @Test func tabCyclesWithSingleArea() {
+        let count = 1
+        #expect((0 + 1) % count == 0)          // Tab: 自分自身に戻る
+        #expect((0 - 1 + count) % count == 0)  // Shift+Tab: 同様
+    }
+
+    // MARK: - ScrollAreaInfo のラベル生成
+
+    @Test func scrollAreaLabelsAreSequential() {
+        let areas = [
+            ScrollAreaInfo(frame: .zero, centerPoint: .zero, label: "1"),
+            ScrollAreaInfo(frame: .zero, centerPoint: .zero, label: "2"),
+            ScrollAreaInfo(frame: .zero, centerPoint: .zero, label: "3"),
+        ]
+        for (i, area) in areas.enumerated() {
+            #expect(area.label == String(i + 1))
+        }
+    }
+}

--- a/Tests/VimursorTests/ScrollModeControllerTests.swift
+++ b/Tests/VimursorTests/ScrollModeControllerTests.swift
@@ -6,40 +6,39 @@ import CoreGraphics
 struct ScrollModeControllerTests {
 
     // MARK: - AX座標 → NSView座標 変換
+    // ScrollAreaView.toNSViewFrame(static) を通じて検証する
     // 変換式: nsY = screenHeight - axY - axHeight
-    // ScrollAreaView.toNSViewFrame と同一ロジックを純粋な数式でテストする
 
     @Test func axToNSViewYConversion() {
-        let screenHeight: CGFloat = 1000
-        let axY: CGFloat = 100
-        let height: CGFloat = 200
-        let nsY = screenHeight - axY - height
+        let axFrame = CGRect(x: 0, y: 100, width: 500, height: 200)
+        let nsFrame = ScrollAreaView.toNSViewFrame(axFrame, screenHeight: 1000)
         // nsY = 1000 - 100 - 200 = 700
-        #expect(nsY == 700)
+        #expect(nsFrame.origin.y == 700)
+        #expect(nsFrame.origin.x == 0)
+        #expect(nsFrame.width == 500)
+        #expect(nsFrame.height == 200)
     }
 
     @Test func axToNSViewYConversionTopOfScreen() {
-        let screenHeight: CGFloat = 800
-        let axY: CGFloat = 0
-        let height: CGFloat = 100
-        let nsY = screenHeight - axY - height
+        let axFrame = CGRect(x: 0, y: 0, width: 300, height: 100)
+        let nsFrame = ScrollAreaView.toNSViewFrame(axFrame, screenHeight: 800)
         // nsY = 800 - 0 - 100 = 700
-        #expect(nsY == 700)
+        #expect(nsFrame.origin.y == 700)
     }
 
     @Test func axToNSViewYConversionBottomOfScreen() {
-        let screenHeight: CGFloat = 800
-        let axY: CGFloat = 700
-        let height: CGFloat = 100
-        let nsY = screenHeight - axY - height
+        let axFrame = CGRect(x: 0, y: 700, width: 300, height: 100)
+        let nsFrame = ScrollAreaView.toNSViewFrame(axFrame, screenHeight: 800)
         // nsY = 800 - 700 - 100 = 0
-        #expect(nsY == 0)
+        #expect(nsFrame.origin.y == 0)
     }
 
     @Test func axToNSViewXIsUnchanged() {
-        // x 座標は変換不要（スクリーン左端を共有）
-        let axX: CGFloat = 250
-        #expect(axX == 250)
+        let axFrame = CGRect(x: 250, y: 100, width: 400, height: 300)
+        let nsFrame = ScrollAreaView.toNSViewFrame(axFrame, screenHeight: 1000)
+        #expect(nsFrame.origin.x == 250)
+        #expect(nsFrame.width == 400)
+        #expect(nsFrame.height == 300)
     }
 
     // MARK: - 数字キー → 0-based インデックス変換
@@ -67,24 +66,29 @@ struct ScrollModeControllerTests {
 
     // MARK: - Tab / Shift+Tab 循環ロジック
 
+    /// ScrollModeController の selectArea と同じ循環計算をヘルパーとして切り出す
+    private func nextIndex(current: Int, count: Int, direction: Int) -> Int {
+        (current + direction + count) % count
+    }
+
     @Test func tabCyclesForward() {
         let count = 3
-        #expect((0 + 1) % count == 1)
-        #expect((1 + 1) % count == 2)
-        #expect((2 + 1) % count == 0)  // 末尾 → 先頭へ循環
+        #expect(nextIndex(current: 0, count: count, direction: +1) == 1)
+        #expect(nextIndex(current: 1, count: count, direction: +1) == 2)
+        #expect(nextIndex(current: 2, count: count, direction: +1) == 0)  // 末尾 → 先頭へ循環
     }
 
     @Test func shiftTabCyclesBackward() {
         let count = 3
-        #expect((0 - 1 + count) % count == 2)  // 先頭 → 末尾へ循環
-        #expect((1 - 1 + count) % count == 0)
-        #expect((2 - 1 + count) % count == 1)
+        #expect(nextIndex(current: 0, count: count, direction: -1) == 2)  // 先頭 → 末尾へ循環
+        #expect(nextIndex(current: 1, count: count, direction: -1) == 0)
+        #expect(nextIndex(current: 2, count: count, direction: -1) == 1)
     }
 
     @Test func tabCyclesWithSingleArea() {
         let count = 1
-        #expect((0 + 1) % count == 0)          // Tab: 自分自身に戻る
-        #expect((0 - 1 + count) % count == 0)  // Shift+Tab: 同様
+        #expect(nextIndex(current: 0, count: count, direction: +1) == 0)  // Tab: 自分自身に戻る
+        #expect(nextIndex(current: 0, count: count, direction: -1) == 0)  // Shift+Tab: 同様
     }
 
     // MARK: - ScrollAreaInfo のラベル生成

--- a/docs/plans/v0.5.md
+++ b/docs/plans/v0.5.md
@@ -1,0 +1,563 @@
+# v0.5 実装プラン — スクロールモード改善（領域選択UI）
+
+アーキテクチャ・制約の詳細は `overview.md` を参照。
+実装パターンは `HintMode/HintModeController.swift` および `ScrollMode/ScrollModeController.swift` を参照。
+
+---
+
+## v0.5 の完了条件
+
+1. `Cmd+Shift+J` でスクロールモードが起動し、フォーカスアプリの全スクロール領域に番号ラベル（1, 2, 3...）とボーダーが表示される
+2. 起動直後は index=0 の領域が自動選択状態（青ボーダー）になり、即スクロール可能
+3. `1`〜`9` キーで対応する番号の領域に切り替えられる
+4. `Tab` で次の領域へ、`Shift+Tab` で前の領域へ循環切り替えできる
+5. `j/k/u/d` で選択中の領域をスクロールできる
+6. `ESC` でスクロールモードを終了し、オーバーレイが消える
+7. スクロール領域が1つのときも選択UIを表示し（青ボーダー）、即スクロール可能
+8. HintMode / SearchMode がアクティブな間は `Cmd+Shift+J` を無視する（既存動作を維持）
+
+---
+
+## 実装ファイル一覧
+
+### 新規作成
+
+| ファイル | 役割 |
+|---------|------|
+| `Sources/Vimursor/Overlay/ScrollAreaView.swift` | スクロール領域のボーダー・番号バッジ・選択ハイライトを描画する NSView |
+| `Tests/VimursorTests/ScrollModeControllerTests.swift` | AX座標→NSView座標変換ロジックの単体テスト |
+
+### 既存修正
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `Sources/Vimursor/ScrollMode/ScrollTarget.swift` | `enumerateScrollableElements(root:)` 追加（AXツリー全体を走査） |
+| `Sources/Vimursor/ScrollMode/ScrollModeController.swift` | 状態機械を `.fetching` / `.active(areas:selectedIndex:)` に変更。Tab/Shift+Tab/数字キー対応 |
+
+---
+
+## Phase 1: ScrollTarget に全領域列挙を追加
+
+### 追加するデータ型
+
+`ScrollModeController.swift` のファイルトップに `struct ScrollAreaInfo` を定義する（他ファイルからも参照するため internal アクセス）:
+
+```swift
+// ScrollModeController.swift トップに追加
+struct ScrollAreaInfo {
+    let frame: CGRect        // AX スクリーン座標（描画変換用）
+    let centerPoint: CGPoint // CGEvent.location 用（変換不要、スクリーン座標のまま）
+    let label: String        // "1", "2", ...
+}
+```
+
+### ScrollTarget.swift への追加
+
+`findScrollableElement`（既存）はそのまま残し、新関数 `enumerateScrollableElements` を追加する。
+
+```swift
+// ScrollTarget.swift に追加
+
+/// AX ツリーを走査し、スクロール可能な全領域を返す
+/// - スクロール可能ロールの要素を発見したら子への再帰を止める（ネスト重複防止）
+/// - 100×100px 未満の要素はスキップ（ツールバー内の小さな AXList 等を除外）
+static func enumerateScrollableElements(root: AXUIElement) -> [ScrollAreaInfo] {
+    var result: [ScrollAreaInfo] = []
+    collectScrollable(element: root, into: &result, depth: 0)
+    return result
+}
+
+private static let minScrollAreaSize: CGFloat = 100
+
+private static func collectScrollable(
+    element: AXUIElement,
+    into result: inout [ScrollAreaInfo],
+    depth: Int
+) {
+    guard depth < 20 else { return }
+
+    if isScrollable(element: element),
+       let frame = frame(of: element),
+       frame.width >= minScrollAreaSize,
+       frame.height >= minScrollAreaSize {
+        let center = CGPoint(x: frame.midX, y: frame.midY)
+        let label = String(result.count + 1)
+        result.append(ScrollAreaInfo(frame: frame, centerPoint: center, label: label))
+        return  // スクロール領域内には再帰しない（ネスト重複防止）
+    }
+
+    var childrenRef: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, "AXChildren" as CFString, &childrenRef) == .success,
+          let children = childrenRef as? [AXUIElement] else { return }
+    for child in children {
+        collectScrollable(element: child, into: &result, depth: depth + 1)
+    }
+}
+
+/// AX スクリーン座標系（原点:左上）での要素フレームを返す
+private static func frame(of element: AXUIElement) -> CGRect? {
+    var posRef: CFTypeRef?
+    var sizeRef: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, "AXPosition" as CFString, &posRef) == .success,
+          AXUIElementCopyAttributeValue(element, "AXSize" as CFString, &sizeRef) == .success,
+          let posRef, let sizeRef else { return nil }
+    var position = CGPoint.zero
+    var size = CGSize.zero
+    AXValueGetValue(posRef as! AXValue, .cgPoint, &position)
+    AXValueGetValue(sizeRef as! AXValue, .cgSize, &size)
+    guard size.width > 0, size.height > 0 else { return nil }
+    return CGRect(origin: position, size: size)
+}
+```
+
+**注意:** `centerPoint(of:)` は既存のまま残す（`findScrollableElement` が使用中）。
+`frame(of:)` は新規追加し、`enumerateScrollableElements` で使う。
+
+---
+
+## Phase 2: ScrollAreaView の実装
+
+### ファイル: Sources/Vimursor/Overlay/ScrollAreaView.swift
+
+```swift
+import AppKit
+
+@MainActor
+final class ScrollAreaView: NSView {
+    private var areas: [ScrollAreaInfo] = []
+    private var selectedIndex: Int = 0
+    private let screenHeight: CGFloat
+
+    init(screenHeight: CGFloat, frame: NSRect) {
+        self.screenHeight = screenHeight
+        super.init(frame: frame)
+        wantsLayer = true
+    }
+    required init?(coder: NSCoder) { fatalError() }
+
+    func update(areas: [ScrollAreaInfo], selectedIndex: Int) {
+        self.areas = areas
+        self.selectedIndex = selectedIndex
+        needsDisplay = true
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        for (i, area) in areas.enumerated() {
+            let nsFrame = toNSViewFrame(area.frame)
+            drawAreaBorder(nsFrame: nsFrame, isSelected: i == selectedIndex)
+            drawLabelBadge(label: area.label, at: nsFrame)
+        }
+    }
+
+    // AX スクリーン座標（原点:左上）→ NSView 座標（原点:左下）変換
+    private func toNSViewFrame(_ axFrame: CGRect) -> CGRect {
+        let nsY = screenHeight - axFrame.origin.y - axFrame.height
+        return CGRect(x: axFrame.origin.x, y: nsY, width: axFrame.width, height: axFrame.height)
+    }
+
+    private func drawAreaBorder(nsFrame: CGRect, isSelected: Bool) {
+        if isSelected {
+            // 選択中: 青ボーダー (2.5px) + 薄い青塗り
+            NSColor.systemBlue.withAlphaComponent(0.08).setFill()
+            NSBezierPath(roundedRect: nsFrame, xRadius: 4, yRadius: 4).fill()
+            NSColor.systemBlue.withAlphaComponent(0.85).setStroke()
+            let path = NSBezierPath(roundedRect: nsFrame.insetBy(dx: 1.25, dy: 1.25), xRadius: 4, yRadius: 4)
+            path.lineWidth = 2.5
+            path.stroke()
+        } else {
+            // 非選択: グレーボーダー (1px)
+            NSColor.systemGray.withAlphaComponent(0.5).setStroke()
+            let path = NSBezierPath(roundedRect: nsFrame.insetBy(dx: 0.5, dy: 0.5), xRadius: 4, yRadius: 4)
+            path.lineWidth = 1.0
+            path.stroke()
+        }
+    }
+
+    private func drawLabelBadge(label: String, at nsFrame: CGRect) {
+        // バッジサイズ: 22×22、左上角から 6px インセット
+        let badgeSize: CGFloat = 22
+        let badgeRect = CGRect(
+            x: nsFrame.minX + 6,
+            y: nsFrame.maxY - 6 - badgeSize,
+            width: badgeSize,
+            height: badgeSize
+        )
+        // バッジ背景
+        NSColor(white: 0.1, alpha: 0.85).setFill()
+        NSBezierPath(roundedRect: badgeRect, xRadius: 4, yRadius: 4).fill()
+        // バッジテキスト
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.monospacedSystemFont(ofSize: 12, weight: .bold),
+            .foregroundColor: NSColor.white
+        ]
+        let str = label as NSString
+        let strSize = str.size(withAttributes: attrs)
+        let textOrigin = CGPoint(
+            x: badgeRect.midX - strSize.width / 2,
+            y: badgeRect.midY - strSize.height / 2
+        )
+        str.draw(at: textOrigin, withAttributes: attrs)
+    }
+}
+```
+
+**座標変換の注意:**
+- AX 座標: 原点 = スクリーン左上、y 増加 = 下
+- NSView 座標: 原点 = ウィンドウ左下（フルスクリーンパネルなのでスクリーン左下）、y 増加 = 上
+- 変換式: `nsY = screenHeight - axY - axHeight`
+
+---
+
+## Phase 3: ScrollModeController の書き換え
+
+### 状態機械の変更
+
+```swift
+// ScrollModeController.swift
+
+private enum ScrollModeState {
+    case inactive
+    case fetching                                          // 領域列挙中（二重起動防止）
+    case active(areas: [ScrollAreaInfo], selectedIndex: Int) // 領域選択＋スクロール中
+}
+```
+
+### キーコード定数の追加
+
+```swift
+private enum ScrollKeyCode {
+    static let esc: CGKeyCode  = 53
+    static let tab: CGKeyCode  = 48
+    static let j: CGKeyCode    = 38
+    static let k: CGKeyCode    = 40
+    static let d: CGKeyCode    = 2
+    static let u: CGKeyCode    = 32
+    // 数字 1〜9（US キーボード）
+    static let num1: CGKeyCode = 18
+    static let num2: CGKeyCode = 19
+    static let num3: CGKeyCode = 20
+    static let num4: CGKeyCode = 21
+    static let num5: CGKeyCode = 23
+    static let num6: CGKeyCode = 22
+    static let num7: CGKeyCode = 26
+    static let num8: CGKeyCode = 28
+    static let num9: CGKeyCode = 25
+    // num → index (0-based) マッピング
+    static let numToIndex: [CGKeyCode: Int] = [
+        18: 0, 19: 1, 20: 2, 21: 3, 23: 4,
+        22: 5, 26: 6, 28: 7, 25: 8
+    ]
+}
+```
+
+### activate() の変更
+
+```swift
+func activate(overlayWindow: OverlayWindow, hotkeyManager: HotkeyManager) {
+    guard case .inactive = state else { return }  // fetching / active 中はスキップ
+    state = .fetching                              // 同期的に状態変更（二重起動防止）
+    self.overlayWindow = overlayWindow
+    self.hotkeyManager = hotkeyManager
+
+    // キーを消費し始める（fetching 中も他のモードへのキー漏れを防ぐ）
+    hotkeyManager.keyEventHandler = { [weak self] keyCode, flags in
+        guard let self else { return false }
+        Task { @MainActor [weak self] in
+            self?.handleKey(keyCode: keyCode, flags: flags)
+        }
+        return true
+    }
+
+    guard let focusedApp = NSWorkspace.shared.frontmostApplication else {
+        state = .inactive
+        hotkeyManager.keyEventHandler = nil
+        return
+    }
+    let appElement = AXElement(ref: AXUIElementCreateApplication(focusedApp.processIdentifier))
+    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+        let areas = ScrollTarget.enumerateScrollableElements(root: appElement.ref)
+        DispatchQueue.main.async { self?.startScrollMode(areas: areas) }
+    }
+}
+```
+
+### startScrollMode()
+
+```swift
+private func startScrollMode(areas: [ScrollAreaInfo]) {
+    guard case .fetching = state else { return }
+
+    if areas.isEmpty {
+        // スクロール領域が見つからない場合は終了
+        deactivate()
+        return
+    }
+
+    state = .active(areas: areas, selectedIndex: 0)
+
+    // ScrollAreaView を表示
+    let screenHeight = NSScreen.main?.frame.height ?? 0
+    let viewFrame = overlayWindow?.contentView?.bounds ?? .zero
+    let areaView = ScrollAreaView(screenHeight: screenHeight, frame: viewFrame)
+    areaView.autoresizingMask = [.width, .height]
+    areaView.update(areas: areas, selectedIndex: 0)
+    overlayWindow?.contentView?.addSubview(areaView)
+    self.scrollAreaView = areaView
+
+    // SCROLL バナー（左下）
+    let indicator = ScrollIndicatorView(frame: CGRect(x: 12, y: 12, width: 80, height: 28))
+    overlayWindow?.contentView?.addSubview(indicator)
+    self.indicatorView = indicator
+
+    overlayWindow?.show()
+}
+```
+
+### deactivate()
+
+```swift
+func deactivate() {
+    state = .inactive
+    scrollAreaView?.removeFromSuperview()
+    scrollAreaView = nil
+    indicatorView?.removeFromSuperview()
+    indicatorView = nil
+    hotkeyManager?.keyEventHandler = nil
+    overlayWindow?.hide()
+}
+```
+
+### handleKey()
+
+```swift
+private func handleKey(keyCode: CGKeyCode, flags: CGEventFlags) {
+    // fetching 中は ESC のみ受け付ける
+    if case .fetching = state {
+        if keyCode == ScrollKeyCode.esc { deactivate() }
+        return
+    }
+
+    guard case .active(let areas, let selectedIndex) = state else { return }
+
+    // ESC: 終了（修飾キーに関わらず常に有効）
+    if keyCode == ScrollKeyCode.esc {
+        deactivate()
+        return
+    }
+
+    // 修飾キー付きは Tab(Shift+Tab) 以外を無視
+    let isShift = flags.contains(.maskShift)
+    let relevantFlags = flags.intersection([.maskCommand, .maskControl, .maskAlternate])
+    let isShiftOnly = isShift && relevantFlags.isEmpty
+
+    // Tab: 次の領域へ
+    if keyCode == ScrollKeyCode.tab && (flags.intersection([.maskCommand, .maskControl, .maskAlternate]).isEmpty) {
+        let next = isShiftOnly
+            ? (selectedIndex - 1 + areas.count) % areas.count  // Shift+Tab: 逆順
+            : (selectedIndex + 1) % areas.count                 // Tab: 順送り
+        selectArea(index: next, areas: areas)
+        return
+    }
+
+    // 修飾キー付き（Tab 以外）は無視
+    guard relevantFlags.isEmpty && !isShift else { return }
+
+    // 数字キー: 領域選択
+    if let index = ScrollKeyCode.numToIndex[keyCode] {
+        if index < areas.count {
+            selectArea(index: index, areas: areas)
+        }
+        return
+    }
+
+    // スクロールキー
+    let targetPoint = areas[selectedIndex].centerPoint
+    switch keyCode {
+    case ScrollKeyCode.j:
+        ScrollEngine.scroll(amount: .step(direction: .down), targetPoint: targetPoint)
+    case ScrollKeyCode.k:
+        ScrollEngine.scroll(amount: .step(direction: .up), targetPoint: targetPoint)
+    case ScrollKeyCode.d:
+        ScrollEngine.scroll(amount: .halfPage(direction: .down), targetPoint: targetPoint)
+    case ScrollKeyCode.u:
+        ScrollEngine.scroll(amount: .halfPage(direction: .up), targetPoint: targetPoint)
+    default:
+        break
+    }
+}
+
+private func selectArea(index: Int, areas: [ScrollAreaInfo]) {
+    state = .active(areas: areas, selectedIndex: index)
+    scrollAreaView?.update(areas: areas, selectedIndex: index)
+}
+```
+
+### プロパティ
+
+```swift
+@MainActor
+final class ScrollModeController {
+    private var state: ScrollModeState = .inactive
+    // isActive: Bool は削除（state で一元管理）
+    private var scrollAreaView: ScrollAreaView?
+    private var indicatorView: ScrollIndicatorView?
+    private weak var overlayWindow: OverlayWindow?
+    private weak var hotkeyManager: HotkeyManager?
+}
+```
+
+---
+
+## Phase 4: テスト
+
+### Tests/VimursorTests/ScrollModeControllerTests.swift（新規）
+
+AX座標→NSView座標変換は副作用のない純粋ロジックなのでテスト可能。
+
+```swift
+import Testing
+@testable import Vimursor
+
+@Suite
+struct ScrollModeControllerTests {
+
+    // AX座標（原点:左上）→ NSView座標（原点:左下）変換
+    // screenHeight=1000 の場合、axY=100, height=200 → nsY = 1000 - 100 - 200 = 700
+    @Test func axToNSViewYConversion() {
+        let screenHeight: CGFloat = 1000
+        let axY: CGFloat = 100
+        let height: CGFloat = 200
+        let nsY = screenHeight - axY - height
+        #expect(nsY == 700)
+    }
+
+    @Test func axToNSViewYConversionTopOfScreen() {
+        let screenHeight: CGFloat = 800
+        let axY: CGFloat = 0
+        let height: CGFloat = 100
+        let nsY = screenHeight - axY - height
+        #expect(nsY == 700)
+    }
+
+    @Test func axToNSViewYConversionBottomOfScreen() {
+        let screenHeight: CGFloat = 800
+        let axY: CGFloat = 700
+        let height: CGFloat = 100
+        let nsY = screenHeight - axY - height
+        #expect(nsY == 0)
+    }
+
+    // 数字キー → 0-based インデックス変換
+    @Test func numKeyToIndex() {
+        #expect(ScrollKeyCode.numToIndex[18] == 0)  // 1 → index 0
+        #expect(ScrollKeyCode.numToIndex[19] == 1)  // 2 → index 1
+        #expect(ScrollKeyCode.numToIndex[25] == 8)  // 9 → index 8
+    }
+
+    // ScrollAreaInfo のラベル生成（列挙順に 1, 2, 3...）
+    @Test func scrollAreaLabelsAreSequential() {
+        let areas = [
+            ScrollAreaInfo(frame: .zero, centerPoint: .zero, label: "1"),
+            ScrollAreaInfo(frame: .zero, centerPoint: .zero, label: "2"),
+            ScrollAreaInfo(frame: .zero, centerPoint: .zero, label: "3"),
+        ]
+        for (i, area) in areas.enumerated() {
+            #expect(area.label == String(i + 1))
+        }
+    }
+
+    // Tab循環: selectedIndex=2, areas.count=3 → 次は 0
+    @Test func tabCyclesForward() {
+        let count = 3
+        let current = 2
+        let next = (current + 1) % count
+        #expect(next == 0)
+    }
+
+    // Shift+Tab循環: selectedIndex=0, areas.count=3 → 前は 2
+    @Test func shiftTabCyclesBackward() {
+        let count = 3
+        let current = 0
+        let prev = (current - 1 + count) % count
+        #expect(prev == 2)
+    }
+}
+```
+
+---
+
+## 技術的注意点
+
+### スクロール領域内への非再帰（CRITICAL）
+
+`enumerateScrollableElements` はスクロール可能要素を発見したら**子への再帰を止める**。
+これにより `AXScrollArea` → `AXWebArea` のようなネスト構造で両方が収集されるのを防ぐ。
+収集したいのは「ユーザーが操作対象として認識できる領域」であり、その内部の実装詳細ではない。
+
+### fetching 中のキー消費
+
+`activate()` で `keyEventHandler` をセットし、`fetching` 中もキーを消費する。
+これにより、領域列挙中に別のモード（HintMode等）のホットキーがすり抜けるのを防ぐ。
+`fetching` 中は ESC のみ有効（即キャンセル）。
+
+### `isActive` の削除
+
+現行の `ScrollModeController` に `isActive: Bool` と `state: ScrollModeState` が**重複している**。
+v0.5 で `isActive` を削除し、`state` で一元管理する（v0.4 で HintModeController に適用したのと同じ修正）。
+
+### Shift+Tab の flags 解釈
+
+`flags.contains(.maskShift)` で Shift を検出できる。
+Tab のキーコード（48）に Shift が付いている場合が Shift+Tab。
+`.maskCommand` / `.maskControl` / `.maskAlternate` が含まれる場合はシステムショートカットとして無視する。
+
+### 座標系（重要）
+
+| 座標系 | 原点 | y 増加方向 | 用途 |
+|--------|------|-----------|------|
+| AX / CGEvent.location | スクリーン左上 | 下 | AXPosition, ScrollEngine |
+| NSView (OverlayWindow) | スクリーン左下 | 上 | ScrollAreaView の描画 |
+
+変換式: `nsY = screenHeight - axFrame.origin.y - axFrame.height`
+
+---
+
+## 実装チェックリスト
+
+```
+[ ] Phase 1-1: ScrollAreaInfo 構造体を ScrollModeController.swift トップに定義
+[ ] Phase 1-2: ScrollTarget.frame(of:) 追加（private static func）
+[ ] Phase 1-3: ScrollTarget.enumerateScrollableElements(root:) 追加
+[ ] Phase 1 確認: ScrollTarget の既存関数（findScrollableElement, centerPoint）は変更しない
+
+[ ] Phase 2-1: ScrollAreaView.swift 新規作成
+[ ] Phase 2-2: ScrollAreaView.update(areas:selectedIndex:) 実装
+[ ] Phase 2-3: ScrollAreaView.draw(_:) — ボーダー描画（選択/非選択）
+[ ] Phase 2-4: ScrollAreaView.drawLabelBadge() — 番号バッジ描画
+[ ] Phase 2-5: ScrollAreaView.toNSViewFrame(_:) — 座標変換
+
+[ ] Phase 3-1: ScrollModeState に .fetching 追加、.active(areas:selectedIndex:) に変更
+[ ] Phase 3-2: ScrollModeController の isActive: Bool を削除
+[ ] Phase 3-3: ScrollKeyCode に tab / num1〜num9 / numToIndex 追加
+[ ] Phase 3-4: ScrollModeController に scrollAreaView: ScrollAreaView? プロパティ追加
+[ ] Phase 3-5: activate() — state = .fetching で同期ガード、バックグラウンド列挙に変更
+[ ] Phase 3-6: startScrollMode() 追加（ScrollAreaView + ScrollIndicatorView 表示）
+[ ] Phase 3-7: deactivate() — scrollAreaView の removeFromSuperview 追加
+[ ] Phase 3-8: handleKey() — Tab / Shift+Tab / 数字キー処理を追加
+[ ] Phase 3-9: selectArea(index:areas:) ヘルパー追加
+
+[ ] Phase 4-1: ScrollModeControllerTests.swift 新規作成
+[ ] Phase 4-2: 座標変換テスト（3件）
+[ ] Phase 4-3: 数字キー→インデックス変換テスト
+[ ] Phase 4-4: Tab/Shift+Tab 循環テスト
+
+[ ] swift build 成功
+[ ] swift test 全テストパス
+[ ] 手動確認: Cmd+Shift+J でスクロール領域にボーダー+番号が表示される
+[ ] 手動確認: 起動直後から j/k でスクロールできる
+[ ] 手動確認: 数字キーで領域切り替えができる
+[ ] 手動確認: Tab / Shift+Tab で循環切り替えができる
+[ ] 手動確認: 領域が1つのアプリ（TextEdit等）で青ボーダーが表示される
+[ ] 手動確認: HintMode / SearchMode 中に Cmd+Shift+J を押しても何も起きない
+[ ] 手動確認: ESC でオーバーレイ全体が消える
+```


### PR DESCRIPTION
## Summary

- `Cmd+Shift+J` 起動時に、フォーカスアプリの全スクロール領域を AX ツリーから列挙し、番号ラベル（1, 2, 3...）とボーダーをオーバーレイ表示
- 起動直後は index=0 の領域が自動選択（青ボーダー）され、即スクロール可能
- `1`〜`9` キーで対応領域に直接ジャンプ、`Tab` / `Shift+Tab` で循環切り替え

## Changes

- `ScrollTarget`: `enumerateScrollableElements(root:)` 追加。AX ツリーを再帰走査してスクロール可能な全領域を収集（スクロール領域内には再帰しないことでネスト重複を防止、100×100px 未満はスキップ）
- `ScrollAreaView` (新規): 領域ごとにボーダー＋番号バッジを描画するオーバーレイ NSView。AX 座標→NSView 座標変換を担当
- `ScrollModeController`: 状態機械を `fetching` / `active(areas:selectedIndex:)` に変更。`isActive: Bool` を削除し `state` で一元管理

## Test plan

- [ ] `swift test` 全テストパス（40件）
- [ ] 手動確認: `Cmd+Shift+J` でスクロール領域に番号ボーダーが表示される
- [ ] 手動確認: 起動直後から `j/k/u/d` でスクロールできる
- [ ] 手動確認: 数字キーで領域切り替えができる
- [ ] 手動確認: `Tab` / `Shift+Tab` で循環切り替えができる
- [ ] 手動確認: `ESC` でオーバーレイ全体が消える
- [ ] 手動確認: HintMode / SearchMode 中に `Cmd+Shift+J` を押しても何も起きない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Closes #16