### PR TITLE
feat: v0.6 検索モード入力改善・UI刷新

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,9 +1,5 @@
 {
-  "allowedTools": [
-    "Read",
-    "Write",
-    "Edit",
-    "Glob",
-    "Grep"
-  ]
+  "permissions": {
+    "allow": ["Read", "Write", "Edit", "Glob", "Grep"]
+  }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,10 +117,12 @@ swift test --enable-code-coverage  # カバレッジ付きテスト
 
 #### エージェントのツール権限
 
-`~/.claude/settings.json`（グローバル）と `.claude/settings.json`（プロジェクト）の両方で `Read`/`Write`/`Edit`/`Glob`/`Grep` を自動許可済み。
+`~/.claude/settings.json`（グローバル）と `.claude/settings.json`（プロジェクト）の両方で `permissions.allow` に `Read`/`Write`/`Edit`/`Glob`/`Grep` を設定済み。
 `Bash` はサブエージェントに付与しない。`swift build` / `swift test` 等のビルド・テスト実行はメインセッションで行う。
 
-*Rationale: `Bash` は `rm -rf` 等の破壊的コマンドを含むためサブエージェントには与えない。ファイル操作系ツールはグローバル設定で自動許可することでサブエージェントが確認なく実装できる。ビルド確認はメインセッションが責任を持つ。*
+**注意:** `allowedTools`（旧形式）ではなく `permissions.allow`（現行形式）を使うこと。旧形式はバックグラウンドエージェントで正しく認識されない。
+
+*Rationale: `Bash` は `rm -rf` 等の破壊的コマンドを含むためサブエージェントには与えない。ファイル操作系ツールは `permissions.allow` で自動許可することでサブエージェントが確認なく実装できる。ビルド確認はメインセッションが責任を持つ。*
 
 #### メインセッションでのファイル読み込みを最小化
 

--- a/Sources/Vimursor/Accessibility/UIElementEnumerator.swift
+++ b/Sources/Vimursor/Accessibility/UIElementEnumerator.swift
@@ -74,7 +74,7 @@ enum UIElementEnumerator {
         into result: inout [AXUIElement],
         depth: Int
     ) {
-        guard depth < 20, result.count < 500 else { return }
+        guard depth < 30, result.count < 3000 else { return }
 
         var hiddenRef: CFTypeRef?
         if AXUIElementCopyAttributeValue(element, "AXHidden" as CFString, &hiddenRef) == .success,

--- a/Sources/Vimursor/HintMode/HintModeController.swift
+++ b/Sources/Vimursor/HintMode/HintModeController.swift
@@ -60,7 +60,7 @@ final class HintModeController {
         overlayWindow.show()
 
         // CGEventTapスレッドからキーを受け取り、メインスレッドで処理する
-        hotkeyManager.keyEventHandler = { [weak self] keyCode, flags in
+        hotkeyManager.keyEventHandler = { [weak self] keyCode, flags, _ in
             guard let self else { return false }
             Task { @MainActor [weak self] in
                 self?.handleKey(keyCode: keyCode, flags: flags)

--- a/Sources/Vimursor/HotkeyManager.swift
+++ b/Sources/Vimursor/HotkeyManager.swift
@@ -20,8 +20,8 @@ final class HotkeyManager: @unchecked Sendable {
 
     // CGEventTap スレッド（読み取り）とメインスレッド（書き込み）をまたぐため NSLock で保護
     private let handlerLock = NSLock()
-    private var _keyEventHandler: ((CGKeyCode, CGEventFlags) -> Bool)?
-    var keyEventHandler: ((CGKeyCode, CGEventFlags) -> Bool)? {
+    private var _keyEventHandler: ((CGKeyCode, CGEventFlags, String) -> Bool)?
+    var keyEventHandler: ((CGKeyCode, CGEventFlags, String) -> Bool)? {
         get {
             handlerLock.lock()
             defer { handlerLock.unlock() }
@@ -72,7 +72,10 @@ final class HotkeyManager: @unchecked Sendable {
         let keyCode = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
         let flags = event.flags.intersection([.maskCommand, .maskShift, .maskAlternate, .maskControl])
 
-        if let handler = keyEventHandler, handler(keyCode, flags) {
+        // CGEvent から実際の入力文字を取得（Shift 状態を含む）
+        let unicodeString = Self.extractUnicodeString(from: event)
+
+        if let handler = keyEventHandler, handler(keyCode, flags, unicodeString) {
             return nil  // HintModeが消費
         }
 
@@ -98,5 +101,19 @@ final class HotkeyManager: @unchecked Sendable {
         }
 
         return Unmanaged.passRetained(event)
+    }
+
+    /// CGEvent から unicode 文字列を取得するユーティリティ
+    /// IME 通過前のキーコードレベルの文字を返す（Shift 状態は反映される）
+    private static func extractUnicodeString(from event: CGEvent) -> String {
+        var actualLength: Int = 0
+        var chars = [UniChar](repeating: 0, count: 4)
+        event.keyboardGetUnicodeString(
+            maxStringLength: 4,
+            actualStringLength: &actualLength,
+            unicodeString: &chars
+        )
+        guard actualLength > 0 else { return "" }
+        return String(utf16CodeUnits: Array(chars.prefix(actualLength)), count: actualLength)
     }
 }

--- a/Sources/Vimursor/HotkeyManager.swift
+++ b/Sources/Vimursor/HotkeyManager.swift
@@ -72,11 +72,13 @@ final class HotkeyManager: @unchecked Sendable {
         let keyCode = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
         let flags = event.flags.intersection([.maskCommand, .maskShift, .maskAlternate, .maskControl])
 
-        // CGEvent から実際の入力文字を取得（Shift 状態を含む）
-        let unicodeString = Self.extractUnicodeString(from: event)
-
-        if let handler = keyEventHandler, handler(keyCode, flags, unicodeString) {
-            return nil  // HintModeが消費
+        if let handler = keyEventHandler {
+            // CGEvent から実際の入力文字を取得（Shift 状態を含む）
+            // ハンドラ未設定時は不要なので遅延実行する
+            let unicodeString = Self.extractUnicodeString(from: event)
+            if handler(keyCode, flags, unicodeString) {
+                return nil  // HintModeが消費
+            }
         }
 
         if keyCode == KeyCode.space && flags == ModifierFlags.cmdShift {

--- a/Sources/Vimursor/Overlay/OverlayWindow.swift
+++ b/Sources/Vimursor/Overlay/OverlayWindow.swift
@@ -36,11 +36,22 @@ final class OverlayWindow: NSPanel {
         }
     }
 
+    // key window 化を許可（NSPanel のデフォルトは false）
+    override var canBecomeKey: Bool { true }
+
     func show() {
         orderFrontRegardless()
     }
 
+    // 検索モード用: key window として前面表示
+    func showAsKeyWindow() {
+        ignoresMouseEvents = false  // NSTextField がイベントを受信できるようにする
+        makeKeyAndOrderFront(nil)
+    }
+
     func hide() {
+        if isKeyWindow { resignKey() }
+        ignoresMouseEvents = true  // 他のモード用にマウスイベント無視に戻す
         orderOut(nil)
     }
 }

--- a/Sources/Vimursor/ScrollMode/ScrollModeController.swift
+++ b/Sources/Vimursor/ScrollMode/ScrollModeController.swift
@@ -59,7 +59,7 @@ final class ScrollModeController {
         self.overlayWindow = overlayWindow
         self.hotkeyManager = hotkeyManager
 
-        hotkeyManager.keyEventHandler = { [weak self] keyCode, flags in
+        hotkeyManager.keyEventHandler = { [weak self] keyCode, flags, _ in
             guard let self else { return false }
 
             let otherModifiers = flags.intersection([.maskCommand, .maskControl, .maskAlternate])

--- a/Sources/Vimursor/SearchMode/SearchModeController.swift
+++ b/Sources/Vimursor/SearchMode/SearchModeController.swift
@@ -13,6 +13,7 @@ final class SearchModeController {
     private var searchView: SearchView?
     private weak var overlayWindow: OverlayWindow?
     private weak var hotkeyManager: HotkeyManager?
+    private var previousApp: NSRunningApplication?
 
     func activate(overlayWindow: OverlayWindow, hotkeyManager: HotkeyManager) {
         guard !isActive else { return }
@@ -20,6 +21,7 @@ final class SearchModeController {
         self.hotkeyManager = hotkeyManager
 
         guard let focusedApp = NSWorkspace.shared.frontmostApplication else { return }
+        self.previousApp = focusedApp
         let appElement = AXUIElementCreateApplication(focusedApp.processIdentifier)
 
         axManager.fetchSearchableElements(in: appElement) { [weak self] elements in
@@ -41,15 +43,36 @@ final class SearchModeController {
         let view = SearchView(frame: overlayWindow.contentView?.bounds ?? .zero)
         view.autoresizingMask = [.width, .height]
         view.update(query: "", matched: elements)
+
+        // テキスト変更のコールバック登録
+        view.onQueryChanged = { [weak self] newQuery in
+            Task { @MainActor [weak self] in
+                self?.applyQuery(newQuery)
+            }
+        }
+
+        // Enter 処理は NSTextField デリゲートに委譲（IME 変換確定 Enter との区別のため）
+        view.onEnterPressed = { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.executeSearch()
+            }
+        }
+
         overlayWindow.contentView?.addSubview(view)
         searchView = view
 
-        overlayWindow.show()
+        // key window として表示し、NSTextField を first responder に
+        overlayWindow.showAsKeyWindow()
+        NSApp.activate(ignoringOtherApps: true)
+        view.focusSearchField()
 
-        hotkeyManager.keyEventHandler = { [weak self] keyCode, flags in
+        // CGEventTap は ESC のみ処理（Enter は NSTextField デリゲートで処理）
+        hotkeyManager.keyEventHandler = { [weak self] keyCode, flags, _ in
             guard let self else { return false }
+            // ESC (53) のみ消費
+            guard keyCode == 53 else { return false }
             Task { @MainActor [weak self] in
-                self?.handleKey(keyCode: keyCode, flags: flags)
+                self?.deactivate()
             }
             return true
         }
@@ -62,6 +85,8 @@ final class SearchModeController {
         searchView = nil
         hotkeyManager?.keyEventHandler = nil
         overlayWindow?.hide()
+        previousApp?.activate(options: [])
+        previousApp = nil
     }
 
     nonisolated static func filter(
@@ -73,52 +98,21 @@ final class SearchModeController {
         return elements.filter { $0.searchableText.contains(q) }
     }
 
-    private func handleKey(keyCode: CGKeyCode, flags: CGEventFlags) {
-        guard case .active(let elements, let query, _) = state else { return }
-
-        // ESC
-        if keyCode == 53 { deactivate(); return }
-
-        // Backspace
-        if keyCode == 51 {
-            let newQuery = String(query.dropLast())
-            let matched = SearchModeController.filter(elements: elements, query: newQuery)
-            state = .active(elements: elements, query: newQuery, matched: matched)
-            searchView?.update(query: newQuery, matched: matched)
-            return
+    /// Enter 確定時に先頭マッチをクリックする（NSTextField デリゲート経由で呼ばれる）
+    private func executeSearch() {
+        guard case .active(_, _, let matched) = state, let first = matched.first else { return }
+        let frame = first.frame
+        deactivate()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            self?.axManager.clickAt(frame: frame)
         }
-
-        // Enter / Space: 先頭マッチをクリック
-        if keyCode == 36 || keyCode == 49 {
-            guard case .active(_, _, let matched) = state, let first = matched.first else { return }
-            let frame = first.frame
-            deactivate()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
-                self?.axManager.clickAt(frame: frame)
-            }
-            return
-        }
-
-        // 修飾キー付きは無視
-        guard flags.intersection([.maskCommand, .maskControl, .maskAlternate]).isEmpty else { return }
-        guard let char = keyCodeToChar(keyCode) else { return }
-
-        let newQuery = query + char
-        let matched = SearchModeController.filter(elements: elements, query: newQuery)
-        state = .active(elements: elements, query: newQuery, matched: matched)
-        searchView?.update(query: newQuery, matched: matched)
     }
 
-    private func keyCodeToChar(_ keyCode: CGKeyCode) -> String? {
-        let map: [CGKeyCode: String] = [
-            0: "a", 11: "b", 8: "c", 2: "d", 14: "e",
-            3: "f", 5: "g", 4: "h", 34: "i", 38: "j",
-            40: "k", 37: "l", 46: "m", 45: "n", 31: "o",
-            35: "p", 12: "q", 15: "r", 1: "s", 17: "t",
-            32: "u", 9: "v", 13: "w", 7: "x", 16: "y", 6: "z",
-            29: "0", 18: "1", 19: "2", 20: "3", 21: "4",
-            23: "5", 22: "6", 26: "7", 28: "8", 25: "9",
-        ]
-        return map[keyCode]
+    /// NSTextField からのクエリ更新（IME 確定後の文字列を受け取る）
+    private func applyQuery(_ query: String) {
+        guard case .active(let elements, _, _) = state else { return }
+        let matched = SearchModeController.filter(elements: elements, query: query)
+        state = .active(elements: elements, query: query, matched: matched)
+        searchView?.update(query: query, matched: matched)
     }
 }

--- a/Sources/Vimursor/SearchMode/SearchModeController.swift
+++ b/Sources/Vimursor/SearchMode/SearchModeController.swift
@@ -67,7 +67,7 @@ final class SearchModeController {
         view.focusSearchField()
 
         // CGEventTap は ESC のみ処理（Enter は NSTextField デリゲートで処理）
-        hotkeyManager.keyEventHandler = { [weak self] keyCode, flags, _ in
+        hotkeyManager.keyEventHandler = { [weak self] keyCode, _, _ in
             guard let self else { return false }
             // ESC (53) のみ消費
             guard keyCode == 53 else { return false }

--- a/Sources/Vimursor/SearchMode/SearchView.swift
+++ b/Sources/Vimursor/SearchMode/SearchView.swift
@@ -1,19 +1,163 @@
 import AppKit
 
+/// テキスト変更をコントローラに通知するコールバック
+typealias QueryChangedHandler = (String) -> Void
+
+// MARK: - レイアウト定数
+private enum SearchBarLayout {
+    /// フローティングバーの幅（画面幅に対する比率）
+    static let widthRatio: CGFloat = 0.4
+    /// フローティングバーの高さ（px）
+    static let height: CGFloat = 48
+    /// 画面下端からのマージン（px）
+    static let bottomMargin: CGFloat = 80
+    /// フローティングバーの角丸半径（px）
+    static let cornerRadius: CGFloat = 12
+    /// テキストフィールドの左右マージン（px）
+    static let fieldHorizontalMargin: CGFloat = 16
+    /// テキストフィールドの高さ（px）
+    static let fieldHeight: CGFloat = 28
+    /// マッチ件数ラベルの幅（px）
+    static let countLabelWidth: CGFloat = 64
+    /// ドロップシャドウのブラー半径（px）
+    static let shadowRadius: CGFloat = 8
+    /// ドロップシャドウのY方向オフセット（px）
+    static let shadowOffsetY: CGFloat = -2
+    /// ドロップシャドウの不透明度
+    static let shadowOpacity: Float = 1.0
+    /// ドロップシャドウの色の不透明度
+    static let shadowColorAlpha: CGFloat = 0.3
+}
+
+@MainActor
 final class SearchView: NSView {
-    private var query: String = ""
     private var matchedElements: [SearchElementInfo] = []
+    private var query: String = ""
+
+    // ブラー効果付きフローティングバーのコンテナ
+    private let blurContainer: NSVisualEffectView
+
+    // NSTextField（検索バー部分）
+    private let searchField: SearchTextField
+
+    // マッチ件数表示ラベル
+    private let countLabel: NSTextField
+
+    // コントローラからセットされるコールバック
+    var onQueryChanged: QueryChangedHandler?
+    // Enter 確定時のコールバック（IME 変換確定との区別は NSTextField デリゲートが担う）
+    var onEnterPressed: (() -> Void)?
+
+    override init(frame: NSRect) {
+        self.blurContainer = NSVisualEffectView()
+        self.searchField = SearchTextField()
+        self.countLabel = SearchView.makeCountLabel()
+        super.init(frame: frame)
+        setupBlurContainer()
+        setupTextField()
+        setupCountLabel()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    // MARK: - セットアップ
+
+    private func setupBlurContainer() {
+        // ブラー効果の設定
+        blurContainer.material = .hudWindow
+        blurContainer.blendingMode = .behindWindow
+        blurContainer.state = .active
+
+        // 角丸マスク（NSVisualEffectView は layer?.cornerRadius では角丸にならないため maskImage を使う）
+        blurContainer.maskImage = Self.roundedRectMaskImage(cornerRadius: SearchBarLayout.cornerRadius)
+
+        // ドロップシャドウの設定
+        blurContainer.wantsLayer = true
+        blurContainer.shadow = NSShadow()
+        blurContainer.layer?.shadowColor = NSColor.black.withAlphaComponent(SearchBarLayout.shadowColorAlpha).cgColor
+        blurContainer.layer?.shadowOffset = CGSize(width: 0, height: SearchBarLayout.shadowOffsetY)
+        blurContainer.layer?.shadowRadius = SearchBarLayout.shadowRadius
+        blurContainer.layer?.shadowOpacity = SearchBarLayout.shadowOpacity
+
+        addSubview(blurContainer)
+        updateBlurContainerFrame()
+    }
+
+    private func setupTextField() {
+        let fieldWidth = barWidth - SearchBarLayout.fieldHorizontalMargin * 2 - SearchBarLayout.countLabelWidth
+        let fieldY = (SearchBarLayout.height - SearchBarLayout.fieldHeight) / 2
+        searchField.frame = CGRect(
+            x: SearchBarLayout.fieldHorizontalMargin,
+            y: fieldY,
+            width: fieldWidth,
+            height: SearchBarLayout.fieldHeight
+        )
+        // オートリサイズはblurContainer内で幅に追従させる
+        searchField.autoresizingMask = [.width]
+        searchField.delegate = self
+        blurContainer.addSubview(searchField)
+    }
+
+    private func setupCountLabel() {
+        let labelX = barWidth - SearchBarLayout.countLabelWidth - SearchBarLayout.fieldHorizontalMargin
+        let labelY = (SearchBarLayout.height - SearchBarLayout.fieldHeight) / 2
+        countLabel.frame = CGRect(
+            x: labelX,
+            y: labelY,
+            width: SearchBarLayout.countLabelWidth,
+            height: SearchBarLayout.fieldHeight
+        )
+        // オートリサイズはblurContainer内で右端に追従させる
+        countLabel.autoresizingMask = [.minXMargin]
+        blurContainer.addSubview(countLabel)
+    }
+
+    // MARK: - フローティングバーの幅（現在のboundsから算出）
+
+    private var barWidth: CGFloat {
+        bounds.width * SearchBarLayout.widthRatio
+    }
+
+    // MARK: - blurContainerのframeを更新
+
+    private func updateBlurContainerFrame() {
+        let width = barWidth
+        let x = (bounds.width - width) / 2
+        // NSViewの原点は左下なので、下からのマージンをそのまま使う
+        let y = SearchBarLayout.bottomMargin
+        blurContainer.frame = CGRect(x: x, y: y, width: width, height: SearchBarLayout.height)
+    }
+
+    // MARK: - リサイズ対応
+
+    override func resizeSubviews(withOldSize oldSize: NSSize) {
+        super.resizeSubviews(withOldSize: oldSize)
+        updateBlurContainerFrame()
+    }
+
+    // MARK: - Public API
 
     func update(query: String, matched: [SearchElementInfo]) {
         self.query = query
         self.matchedElements = query.isEmpty ? [] : matched
+        // マッチ件数ラベルの更新
+        if query.isEmpty {
+            countLabel.stringValue = ""
+        } else {
+            countLabel.stringValue = "\(matched.count) 件"
+        }
         needsDisplay = true
     }
+
+    func focusSearchField() {
+        window?.makeFirstResponder(searchField)
+    }
+
+    // MARK: - 描画
 
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
         drawHighlights()
-        drawSearchBar()
     }
 
     private func drawHighlights() {
@@ -28,33 +172,74 @@ final class SearchView: NSView {
         }
     }
 
-    private func drawSearchBar() {
-        let barHeight: CGFloat = 52
-        let barRect = CGRect(x: 0, y: 0, width: bounds.width, height: barHeight)
-        NSColor.black.withAlphaComponent(0.80).setFill()
-        NSBezierPath(roundedRect: barRect, xRadius: 0, yRadius: 0).fill()
+    // MARK: - ファクトリ
 
-        let isNoMatch = !query.isEmpty && matchedElements.isEmpty
-        let textColor: NSColor = isNoMatch ? .systemRed : (query.isEmpty ? .systemGray : .white)
-        let displayText = query.isEmpty ? "検索... (Cmd+Shift+/)" : query
-
-        let attrs: [NSAttributedString.Key: Any] = [
-            .font: NSFont.monospacedSystemFont(ofSize: 15, weight: .regular),
-            .foregroundColor: textColor
-        ]
-        (displayText as NSString).draw(at: CGPoint(x: 20, y: 17), withAttributes: attrs)
-
-        if !query.isEmpty {
-            let countText = "\(matchedElements.count) 件"
-            let countAttrs: [NSAttributedString.Key: Any] = [
-                .font: NSFont.systemFont(ofSize: 12, weight: .regular),
-                .foregroundColor: NSColor.systemGray
-            ]
-            let countSize = (countText as NSString).size(withAttributes: countAttrs)
-            (countText as NSString).draw(
-                at: CGPoint(x: bounds.width - countSize.width - 20, y: 19),
-                withAttributes: countAttrs
-            )
+    /// NSVisualEffectView 用の角丸マスク画像を生成する
+    private static func roundedRectMaskImage(cornerRadius: CGFloat) -> NSImage {
+        let maskSize = NSSize(width: cornerRadius * 2 + 1, height: cornerRadius * 2 + 1)
+        let image = NSImage(size: maskSize, flipped: false) { rect in
+            let path = NSBezierPath(roundedRect: rect, xRadius: cornerRadius, yRadius: cornerRadius)
+            NSColor.black.setFill()
+            path.fill()
+            return true
         }
+        image.capInsets = NSEdgeInsets(
+            top: cornerRadius,
+            left: cornerRadius,
+            bottom: cornerRadius,
+            right: cornerRadius
+        )
+        image.resizingMode = .stretch
+        return image
+    }
+
+    private static func makeCountLabel() -> NSTextField {
+        let label = NSTextField()
+        label.isSelectable = false
+        label.isEditable = false
+        label.isBordered = false
+        label.backgroundColor = .clear
+        label.textColor = .secondaryLabelColor
+        label.font = NSFont.systemFont(ofSize: 12, weight: .regular)
+        label.alignment = .right
+        return label
+    }
+}
+
+// MARK: - NSTextFieldDelegate
+extension SearchView: NSTextFieldDelegate {
+    func controlTextDidChange(_ obj: Notification) {
+        guard let field = obj.object as? NSTextField else { return }
+        onQueryChanged?(field.stringValue)
+    }
+
+    /// IME 変換確定中には呼ばれず、通常の Enter 入力時のみ呼ばれる。
+    /// これにより IME の変換確定 Enter と検索実行 Enter を自然に区別できる。
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+        if commandSelector == #selector(NSResponder.insertNewline(_:)) {
+            onEnterPressed?()
+            return true
+        }
+        return false
+    }
+}
+
+// MARK: - SearchTextField（プレースホルダー付きカスタム NSTextField）
+@MainActor
+private final class SearchTextField: NSTextField {
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    private func configure() {
+        isBordered = false
+        backgroundColor = .clear
+        textColor = .white
+        font = NSFont.monospacedSystemFont(ofSize: 15, weight: .regular)
+        placeholderString = "検索... (Cmd+Shift+/)"
+        focusRingType = .none
     }
 }

--- a/Tests/VimursorTests/SearchModeControllerTests.swift
+++ b/Tests/VimursorTests/SearchModeControllerTests.swift
@@ -73,4 +73,23 @@ struct SearchModeControllerTests {
         let result = SearchModeController.filter(elements: elements, query: "save")
         #expect(result.count == 2)
     }
+
+    @Test func filterWithUpperCaseQuery() {
+        let elements = [makeInfo(title: "Save")]
+        let result = SearchModeController.filter(elements: elements, query: "S")
+        #expect(result.count == 1)
+    }
+
+    @Test func filterWithSpaceInQuery() {
+        let elements = [makeInfo(title: "Open in New Tab"), makeInfo(title: "New Window")]
+        let result = SearchModeController.filter(elements: elements, query: "new tab")
+        #expect(result.count == 1)
+        #expect(result.first?.title == "Open in New Tab")
+    }
+
+    @Test func filterIsCaseInsensitiveForFullUpperCase() {
+        let elements = [makeInfo(title: "save file")]
+        let result = SearchModeController.filter(elements: elements, query: "SAVE")
+        #expect(result.count == 1)
+    }
 }

--- a/docs/plans/v0.6.md
+++ b/docs/plans/v0.6.md
@@ -1,0 +1,679 @@
+# v0.6 実装プラン — 検索モード入力拡張（大文字・スペース・日本語 IME 対応）
+
+アーキテクチャ・制約の詳細は `overview.md` を参照。
+実装パターンは `SearchMode/SearchModeController.swift` および `HotkeyManager.swift` を参照。
+
+---
+
+## v0.6 の完了条件
+
+1. 検索モードで大文字を入力できる（`Shift+a` → `A` がクエリに追加される）
+2. 検索モードでスペースを入力できる（keyCode 49 がクエリ文字 `" "` として扱われる）
+3. 確定キーは **Enter のみ**（Space は確定から外す）
+4. 検索モードで日本語 IME 変換が可能（ひらがな・カタカナ・漢字でフィルタできる）
+5. HintMode / ScrollMode の動作は一切変わらない
+6. 既存テスト (`swift test`) が全件パスする
+
+---
+
+## 実装ファイル一覧
+
+### Phase 1 修正ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `Sources/Vimursor/HotkeyManager.swift` | `keyEventHandler` の型を `((CGKeyCode, CGEventFlags, String) -> Bool)?` に変更。`handleEvent` で `CGEvent.keyboardGetUnicodeString` を呼んで unicode 文字列を取得し、第3引数として渡す |
+| `Sources/Vimursor/HintMode/HintModeController.swift` | `keyEventHandler` の第3引数 `_` を受け取るよう更新。ロジック変更なし |
+| `Sources/Vimursor/ScrollMode/ScrollModeController.swift` | `keyEventHandler` の第3引数 `_` を受け取るよう更新。ロジック変更なし |
+| `Sources/Vimursor/SearchMode/SearchModeController.swift` | `keyEventHandler` の第3引数 `unicodeString` を使って文字入力処理。`keyCodeToChar()` 廃止。Space 確定を削除し Enter のみ確定に変更 |
+
+### Phase 2 修正ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `Sources/Vimursor/Overlay/OverlayWindow.swift` | `canBecomeKey` を `true` で override。`makeKeyAndOrderFront(_:)` を `showAsKeyWindow()` メソッドとして追加。`hide()` に `resignKey()` 呼び出しを追加 |
+| `Sources/Vimursor/SearchMode/SearchView.swift` | NSTextField を内包するコンテナに再設計。NSTextFieldDelegate を実装し、テキスト変更を `onQueryChanged` コールバックで通知 |
+| `Sources/Vimursor/SearchMode/SearchModeController.swift` | Phase 1 の `keyEventHandler` 文字入力処理を削除。`SearchView.onQueryChanged` でフィルタを更新。ESC / Enter のみ `keyEventHandler` で処理 |
+
+### テストファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `Tests/VimursorTests/SearchModeControllerTests.swift` | `filter()` の既存テストは変更なし。Phase 1 で追加: 大文字フィルタ / スペース含むクエリのテスト |
+
+---
+
+## Phase 1: 大文字 + スペース対応（keyEventHandler シグネチャ変更）
+
+**目標:** Shift キーを含む実際の文字（大文字・記号）およびスペースを検索クエリに入力できるようにする。既存の HintMode / ScrollMode には影響しない。
+
+### 設計判断: keyEventHandler シグネチャの変更アプローチ
+
+**採用案: シグネチャに `String` を追加する**
+
+```swift
+// Before
+var keyEventHandler: ((CGKeyCode, CGEventFlags) -> Bool)?
+
+// After
+var keyEventHandler: ((CGKeyCode, CGEventFlags, String) -> Bool)?
+```
+
+**理由:**
+- `CGEvent.keyboardGetUnicodeString` は CGEvent オブジェクト自体が必要なため、CGEventTap コールバック内（`handleEvent`）でのみ呼べる。コールバックの外に CGEvent を持ち出すことは unsafe。
+- シグネチャを `((CGEvent) -> Bool)?` に変えると、`CGEvent` が `Sendable` 非準拠のため Swift 6 の concurrency チェックに違反する恐れがある。
+- `String`（値型・Sendable 準拠）だけを追加する案が最も安全で変更範囲が小さい。
+- HintMode / ScrollMode のハンドラは `_` で第3引数を無視するだけで済む。
+
+**却下案: `((CGEvent) -> Bool)?`**
+- `CGEvent` は `Sendable` 非準拠。スレッド境界を超える際に Swift 6 コンパイラ警告が出る可能性がある。
+- 各コントローラが CGEvent の生 API を直接使うことになり、抽象レイヤーが薄くなる。
+
+**却下案: Phase 1 はシグネチャを変えず暫定対応**
+- Phase 2 で NSTextField に移行した後、Phase 1 の暫定コードが残骸になる。二度の修正より一度のシグネチャ変更の方がコスト低。
+
+---
+
+### 1-1. HotkeyManager.swift: シグネチャ変更と unicode 文字列取得
+
+**ファイル:** `Sources/Vimursor/HotkeyManager.swift`
+
+変更箇所は2点のみ: `_keyEventHandler` の型と `handleEvent` 内の呼び出し。
+
+```swift
+// 変更前
+private var _keyEventHandler: ((CGKeyCode, CGEventFlags) -> Bool)?
+var keyEventHandler: ((CGKeyCode, CGEventFlags) -> Bool)? {
+
+// 変更後
+private var _keyEventHandler: ((CGKeyCode, CGEventFlags, String) -> Bool)?
+var keyEventHandler: ((CGKeyCode, CGEventFlags, String) -> Bool)? {
+```
+
+`handleEvent` に unicode 文字列の取得ロジックを追加:
+
+```swift
+private func handleEvent(
+    proxy: CGEventTapProxy,
+    type: CGEventType,
+    event: CGEvent
+) -> Unmanaged<CGEvent>? {
+    guard type == .keyDown else { return Unmanaged.passRetained(event) }
+
+    let keyCode = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
+    let flags = event.flags.intersection([.maskCommand, .maskShift, .maskAlternate, .maskControl])
+
+    // CGEvent から実際の入力文字を取得（Shift 状態を含む）
+    let unicodeString = Self.extractUnicodeString(from: event)
+
+    if let handler = keyEventHandler, handler(keyCode, flags, unicodeString) {
+        return nil
+    }
+
+    // 既存のホットキー判定（変更なし）
+    // ...
+
+    return Unmanaged.passRetained(event)
+}
+
+/// CGEvent から unicode 文字列を取得するユーティリティ
+/// IME 通過前のキーコードレベルの文字を返す（Shift 状態は反映される）
+private static func extractUnicodeString(from event: CGEvent) -> String {
+    var actualLength: UniCharCount = 0
+    var chars = [UniChar](repeating: 0, count: 4)
+    event.keyboardGetUnicodeString(
+        maxStringLength: 4,
+        actualStringLength: &actualLength,
+        unicodeString: &chars
+    )
+    guard actualLength > 0 else { return "" }
+    return String(utf16CodeUnits: Array(chars.prefix(actualLength)), count: actualLength)
+}
+```
+
+---
+
+### 1-2. HintModeController.swift: 第3引数を無視するよう更新
+
+**ファイル:** `Sources/Vimursor/HintMode/HintModeController.swift`
+
+`startHintMode()` 内の `keyEventHandler` の設定箇所のみ変更:
+
+```swift
+// 変更前
+hotkeyManager.keyEventHandler = { [weak self] keyCode, flags in
+
+// 変更後
+hotkeyManager.keyEventHandler = { [weak self] keyCode, flags, _ in
+```
+
+`handleKey(keyCode:flags:)` の内部実装は変更なし。
+
+---
+
+### 1-3. ScrollModeController.swift: 第3引数を無視するよう更新
+
+**ファイル:** `Sources/Vimursor/ScrollMode/ScrollModeController.swift`
+
+`activate()` 内の `keyEventHandler` の設定箇所のみ変更:
+
+```swift
+// 変更前
+hotkeyManager.keyEventHandler = { [weak self] keyCode, flags in
+
+// 変更後
+hotkeyManager.keyEventHandler = { [weak self] keyCode, flags, _ in
+```
+
+それ以外の変更なし。
+
+---
+
+### 1-4. SearchModeController.swift: unicode 文字列を使う入力処理に変更
+
+**ファイル:** `Sources/Vimursor/SearchMode/SearchModeController.swift`
+
+主な変更点:
+- `keyEventHandler` の第3引数 `unicodeString` を受け取る
+- `keyCodeToChar()` メソッドを削除
+- Space（keyCode 49）を確定から外し、Enter（keyCode 36）のみ確定に変更
+- Space は通常の文字入力として `unicodeString` 経由で処理
+
+```swift
+private func startSearchMode(
+    elements: [SearchElementInfo],
+    overlayWindow: OverlayWindow,
+    hotkeyManager: HotkeyManager
+) {
+    // ... 既存のビュー設定コード（変更なし）
+
+    hotkeyManager.keyEventHandler = { [weak self] keyCode, flags, unicodeString in
+        guard let self else { return false }
+        Task { @MainActor [weak self] in
+            self?.handleKey(keyCode: keyCode, flags: flags, unicodeString: unicodeString)
+        }
+        return true
+    }
+}
+
+private func handleKey(keyCode: CGKeyCode, flags: CGEventFlags, unicodeString: String) {
+    guard case .active(let elements, let query, _) = state else { return }
+
+    // ESC: 常に有効
+    if keyCode == 53 { deactivate(); return }
+
+    // Backspace
+    if keyCode == 51 {
+        let newQuery = String(query.dropLast())
+        let matched = SearchModeController.filter(elements: elements, query: newQuery)
+        state = .active(elements: elements, query: newQuery, matched: matched)
+        searchView?.update(query: newQuery, matched: matched)
+        return
+    }
+
+    // Enter のみ確定（Space は確定から外す）
+    if keyCode == 36 {
+        guard case .active(_, _, let matched) = state, let first = matched.first else { return }
+        let frame = first.frame
+        deactivate()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            self?.axManager.clickAt(frame: frame)
+        }
+        return
+    }
+
+    // 修飾キー付きは無視（Cmd/Ctrl/Alt）
+    // 注意: Shift のみはここで無視しない（大文字入力のため）
+    guard flags.intersection([.maskCommand, .maskControl, .maskAlternate]).isEmpty else { return }
+
+    // unicodeString が空またはコントロール文字の場合は無視
+    guard !unicodeString.isEmpty,
+          let scalar = unicodeString.unicodeScalars.first,
+          scalar.value >= 32  // スペース (0x20) 以上の印刷可能文字
+    else { return }
+
+    let newQuery = query + unicodeString
+    let matched = SearchModeController.filter(elements: elements, query: newQuery)
+    state = .active(elements: elements, query: newQuery, matched: matched)
+    searchView?.update(query: newQuery, matched: matched)
+}
+
+// keyCodeToChar() は削除
+```
+
+---
+
+### Phase 1 動作確認
+
+```bash
+cd /Users/souheikodama/Desktop/repos/Vimursor
+swift build && .build/debug/Vimursor
+# Cmd+Shift+/ で検索モードを起動
+# 大文字入力: Shift+s → "S" がクエリに追加される
+# スペース入力: Space → " " がクエリに追加される（確定されない）
+# Enter → 先頭マッチをクリックして終了
+# HintMode (Cmd+Shift+Space): 従来どおり動作する
+# ScrollMode (Cmd+Shift+J): 従来どおり動作する
+```
+
+---
+
+## Phase 2: 日本語 IME 対応（NSTextField によるアーキテクチャ変更）
+
+**目標:** NSTextField を検索バーに埋め込み、IME 変換を通した日本語入力を可能にする。CGEventTap は ESC / Enter のみ処理し、通常文字入力は NSTextField に委譲する。
+
+### Phase 2 の設計概要
+
+```
+[Before: Phase 1]
+キー入力 → CGEventTap → keyEventHandler → SearchModeController.handleKey() → フィルタ更新
+
+[After: Phase 2]
+通常文字 → IME → NSTextField → NSTextFieldDelegate.controlTextDidChange → フィルタ更新
+ESC/Enter → CGEventTap → keyEventHandler → SearchModeController.handleControlKey() → 終了/確定
+```
+
+**NSTextField を使う理由:**
+- CGEventTap は IME の変換プロセスより前にキーを捕捉するため、IME が介入できない
+- NSTextField は macOS の標準テキスト入力スタックを使うため、IME が自動的に機能する
+- first responder にするには OverlayWindow が key window である必要がある
+
+---
+
+### 2-1. OverlayWindow.swift: key window 対応
+
+**ファイル:** `Sources/Vimursor/Overlay/OverlayWindow.swift`
+
+OverlayWindow は現在 `NSPanel` のサブクラス。`canBecomeKey` は `NSPanel` のデフォルトで `false`。検索モード中のみ key window にしたい。
+
+```swift
+@MainActor
+final class OverlayWindow: NSPanel {
+    // 既存の override init / configure() はそのまま
+
+    // key window 化を許可（NSPanel のデフォルトは false）
+    override var canBecomeKey: Bool { true }
+
+    func show() {
+        orderFrontRegardless()
+    }
+
+    // 検索モード用: key window として前面表示
+    func showAsKeyWindow() {
+        makeKeyAndOrderFront(nil)
+    }
+
+    func hide() {
+        if isKeyWindow { resignKey() }
+        orderOut(nil)
+    }
+}
+```
+
+**他モードへの影響:**
+- `show()` は変更しない（HintMode / ScrollMode は `show()` を使う）
+- `showAsKeyWindow()` は SearchMode 専用。HintMode / ScrollMode は呼ばない
+- `canBecomeKey = true` にしても、`show()` を使う限り key window にはならない（`orderFrontRegardless()` はフォーカスを奪わない）
+
+---
+
+### 2-2. SearchView.swift: NSTextField を埋め込む
+
+**ファイル:** `Sources/Vimursor/SearchMode/SearchView.swift`
+
+現在の `SearchView` は `draw()` で検索バーを手描きしている。Phase 2 では NSTextField を実際に配置するため、レイアウトを再設計する。
+
+既存の `drawHighlights()` ロジックは残しつつ、検索バー部分を NSTextField で置き換える。
+
+```swift
+import AppKit
+
+/// テキスト変更をコントローラに通知するコールバック
+typealias QueryChangedHandler = (String) -> Void
+
+@MainActor
+final class SearchView: NSView {
+    private var matchedElements: [SearchElementInfo] = []
+
+    // NSTextField（検索バー部分）
+    private let searchField: SearchTextField
+
+    // コントローラからセットされるコールバック
+    var onQueryChanged: QueryChangedHandler?
+
+    override init(frame: NSRect) {
+        self.searchField = SearchTextField()
+        super.init(frame: frame)
+        setupTextField()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    private func setupTextField() {
+        let barHeight: CGFloat = 52
+        searchField.frame = CGRect(x: 20, y: 8, width: bounds.width - 40, height: barHeight - 16)
+        searchField.autoresizingMask = [.width]
+        searchField.delegate = self
+        addSubview(searchField)
+    }
+
+    func update(query: String, matched: [SearchElementInfo]) {
+        self.matchedElements = query.isEmpty ? [] : matched
+        needsDisplay = true
+    }
+
+    func focusSearchField() {
+        window?.makeFirstResponder(searchField)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        drawHighlights()
+        drawSearchBar()
+    }
+
+    private func drawHighlights() {
+        for info in matchedElements {
+            let path = NSBezierPath(roundedRect: info.frame.insetBy(dx: -2, dy: -2), xRadius: 4, yRadius: 4)
+            NSColor.systemGreen.withAlphaComponent(0.85).setStroke()
+            path.lineWidth = 2.5
+            path.stroke()
+            NSColor.systemGreen.withAlphaComponent(0.12).setFill()
+            path.fill()
+        }
+    }
+
+    private func drawSearchBar() {
+        // 検索バー背景のみ描画（テキストは NSTextField が担う）
+        let barHeight: CGFloat = 52
+        let barRect = CGRect(x: 0, y: 0, width: bounds.width, height: barHeight)
+        NSColor.black.withAlphaComponent(0.80).setFill()
+        NSBezierPath(roundedRect: barRect, xRadius: 0, yRadius: 0).fill()
+    }
+}
+
+// MARK: - NSTextFieldDelegate
+extension SearchView: NSTextFieldDelegate {
+    func controlTextDidChange(_ obj: Notification) {
+        guard let field = obj.object as? NSTextField else { return }
+        onQueryChanged?(field.stringValue)
+    }
+}
+
+// MARK: - SearchTextField（プレースホルダー付きカスタム NSTextField）
+@MainActor
+private final class SearchTextField: NSTextField {
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    private func configure() {
+        isBordered = false
+        backgroundColor = .clear
+        textColor = .white
+        font = NSFont.monospacedSystemFont(ofSize: 15, weight: .regular)
+        placeholderString = "検索... (Cmd+Shift+/)"
+        focusRingType = .none
+    }
+}
+```
+
+---
+
+### 2-3. SearchModeController.swift: NSTextField デリゲートに移行
+
+**ファイル:** `Sources/Vimursor/SearchMode/SearchModeController.swift`
+
+Phase 1 で実装した文字入力処理（`unicodeString` 経由）を削除し、`onQueryChanged` コールバックに置き換える。ESC / Enter のみ `keyEventHandler` で処理する。
+
+```swift
+private func startSearchMode(
+    elements: [SearchElementInfo],
+    overlayWindow: OverlayWindow,
+    hotkeyManager: HotkeyManager
+) {
+    state = .active(elements: elements, query: "", matched: elements)
+    isActive = true
+
+    let view = SearchView(frame: overlayWindow.contentView?.bounds ?? .zero)
+    view.autoresizingMask = [.width, .height]
+    view.update(query: "", matched: elements)
+
+    // テキスト変更のコールバック登録
+    view.onQueryChanged = { [weak self] newQuery in
+        Task { @MainActor [weak self] in
+            self?.applyQuery(newQuery)
+        }
+    }
+
+    overlayWindow.contentView?.addSubview(view)
+    searchView = view
+
+    // key window として表示し、NSTextField を first responder に
+    overlayWindow.showAsKeyWindow()
+    view.focusSearchField()
+
+    // CGEventTap は ESC / Enter のみ処理
+    hotkeyManager.keyEventHandler = { [weak self] keyCode, flags, _ in
+        guard let self else { return false }
+        // ESC (53) と Enter (36) のみ消費
+        guard keyCode == 53 || keyCode == 36 else { return false }
+        Task { @MainActor [weak self] in
+            self?.handleControlKey(keyCode: keyCode)
+        }
+        return true
+    }
+}
+
+/// ESC / Enter のみ処理（通常文字は NSTextField デリゲートが処理）
+private func handleControlKey(keyCode: CGKeyCode) {
+    // ESC: キャンセル
+    if keyCode == 53 { deactivate(); return }
+
+    // Enter: 先頭マッチをクリック
+    if keyCode == 36 {
+        guard case .active(_, _, let matched) = state, let first = matched.first else { return }
+        let frame = first.frame
+        deactivate()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            self?.axManager.clickAt(frame: frame)
+        }
+    }
+}
+
+/// NSTextField からのクエリ更新（IME 確定後の文字列を受け取る）
+private func applyQuery(_ query: String) {
+    guard case .active(let elements, _, _) = state else { return }
+    let matched = SearchModeController.filter(elements: elements, query: query)
+    state = .active(elements: elements, query: query, matched: matched)
+    searchView?.update(query: query, matched: matched)
+}
+```
+
+**削除するもの:**
+- `handleKey(keyCode:flags:unicodeString:)` メソッド全体（Phase 1 で実装したもの）
+- `unicodeString` を使う文字入力ロジック
+
+**残すもの:**
+- `filter()` 純粋関数（変更なし）
+- `state` 管理ロジック（変更なし）
+
+---
+
+### Phase 2 動作確認
+
+```bash
+cd /Users/souheikodama/Desktop/repos/Vimursor
+swift build && .build/debug/Vimursor
+# Cmd+Shift+/ で検索モードを起動
+# 日本語入力: IME で「ファイル」と変換してフィルタ確認
+# 英大文字: Shift+s → "S" で確認
+# スペース: Space → " " で確認（フィルタ更新される）
+# Enter → 先頭マッチをクリックして終了
+# ESC → キャンセルして終了
+# HintMode / ScrollMode: 従来どおり動作する（key window を奪わない）
+```
+
+---
+
+## 他モード（HintMode / ScrollMode）への影響
+
+| 変更内容 | HintMode への影響 | ScrollMode への影響 |
+|---------|----------------|------------------|
+| `keyEventHandler` 第3引数 `String` 追加 | ハンドラで `_` として無視するのみ。ロジック変更なし | 同左 |
+| `OverlayWindow.canBecomeKey = true` | `show()` を使うため key window にならない。影響なし | 同左 |
+| `OverlayWindow.showAsKeyWindow()` 追加 | 呼び出さない。影響なし | 同左 |
+| `OverlayWindow.hide()` に `resignKey()` 追加 | HintMode では key window でないため `resignKey()` は無効呼び出し（`isKeyWindow == false` でスキップ）。影響なし | 同左 |
+
+---
+
+## テスト計画
+
+### 既存テスト（変更なし、パス確認のみ）
+
+`Tests/VimursorTests/SearchModeControllerTests.swift` の全8件は `filter()` 純粋関数のテストのみで、入力処理に依存しない。Phase 1・2 後もそのままパスする。
+
+### Phase 1 で追加するテスト
+
+`Tests/VimursorTests/SearchModeControllerTests.swift` に追加:
+
+```swift
+@Test func filterWithUpperCaseQuery() {
+    let elements = [makeInfo(title: "Save")]
+    let result = SearchModeController.filter(elements: elements, query: "S")
+    #expect(result.count == 1)
+}
+
+@Test func filterWithSpaceInQuery() {
+    let elements = [makeInfo(title: "Open in New Tab"), makeInfo(title: "New Window")]
+    let result = SearchModeController.filter(elements: elements, query: "new tab")
+    #expect(result.count == 1)
+    #expect(result.first?.title == "Open in New Tab")
+}
+
+@Test func filterIsCaseInsensitiveForFullUpperCase() {
+    let elements = [makeInfo(title: "save file")]
+    let result = SearchModeController.filter(elements: elements, query: "SAVE")
+    #expect(result.count == 1)
+}
+```
+
+### 手動テスト（自動化困難）
+
+| テスト項目 | 確認方法 |
+|-----------|---------|
+| 大文字入力 | Shift+a → 検索バーに "A" 表示 |
+| スペース入力 | Space → 検索バーにスペース追加（確定されない） |
+| Enter 確定 | Enter → クリック実行・モード終了 |
+| Space 非確定 | Space を押しても確定しない |
+| 日本語 IME (Phase 2) | 「ほ」入力→変換候補表示→「本」Enter確定→フィルタ更新 |
+| HintMode 動作 | Cmd+Shift+Space → 従来どおりヒント表示 |
+| ScrollMode 動作 | Cmd+Shift+J → 従来どおりスクロール領域表示 |
+| SearchMode 中 HintMode 起動防止 | 検索中に Cmd+Shift+Space → 何も起きない |
+
+---
+
+## 技術的注意点
+
+### CGEvent.keyboardGetUnicodeString の制約（CRITICAL）
+
+`CGEvent.keyboardGetUnicodeString` は CGEventTap コールバック内（`handleEvent`）でのみ呼ぶ。CGEvent を `handleEvent` の外に持ち出してはならない。理由:
+
+1. CGEventTap のコールバックが返った後、CGEvent オブジェクトの生存保証がない
+2. CGEvent は `Sendable` 非準拠のため、他スレッドへの受け渡しは Swift 6 で警告/エラーになる
+3. `Unmanaged.passRetained(event)` で返却した後に event を使うことは undefined behavior
+
+この計画では `HotkeyManager.handleEvent` 内で文字列（`String`・値型）に変換し、`keyEventHandler` に渡す。
+
+### 印刷不可能文字のフィルタリング
+
+`CGEvent.keyboardGetUnicodeString` はコントロール文字（0x00〜0x1F）も返す場合がある（例: Backspace は 0x7F、Tab は 0x09）。これらはクエリに追加しない。フィルタリング条件:
+
+```swift
+guard let scalar = unicodeString.unicodeScalars.first,
+      scalar.value >= 32  // スペース(0x20)以上の印刷可能文字のみ
+else { return }
+```
+
+### OverlayWindow の key window 化とアプリ切り替え（Phase 2）
+
+`showAsKeyWindow()` で検索モードを起動すると、Vimursor が front application になり、検索対象のアプリがバックグラウンドに移動する可能性がある。ただし:
+
+- Vimursor は `NSApplication.ActivationPolicy` の設定次第で Dock / App Switcher に表示されない
+- key window になってもフロントアプリとして「見える」ことはない
+- `deactivate()` で `resignKey()` を呼べばフォーカスは元のアプリに戻る
+
+### NSTextField と CGEventTap の優先順位（Phase 2・CRITICAL）
+
+CGEventTap (`.headInsertEventTap`) はシステムレベルで最初にキーを捕捉する:
+
+1. CGEventTap (`.headInsertEventTap`) — **最優先**
+2. NSTextField（first responder）
+
+つまり CGEventTap が先に呼ばれるため、Phase 2 では `keyEventHandler` で ESC / Enter を消費し（`return true`）、それ以外は `return false` とすることで NSTextField にキーが届く。
+
+### SearchView の NSTextField フォーカス管理（Phase 2）
+
+`view.focusSearchField()` は `window?.makeFirstResponder(searchField)` を呼ぶが、`window` は `addSubview` 後でないと `nil` のため、`overlayWindow.showAsKeyWindow()` の**後**に呼ぶ順序を守ること:
+
+```swift
+// 正しい順序
+overlayWindow.contentView?.addSubview(view)  // 1. ビューを追加
+overlayWindow.showAsKeyWindow()              // 2. key window として表示
+view.focusSearchField()                     // 3. first responder を設定
+```
+
+---
+
+## 実装チェックリスト
+
+```
+--- Phase 1: 大文字 + スペース対応 ---
+[ ] 1-1: HotkeyManager.swift — _keyEventHandler 型を ((CGKeyCode, CGEventFlags, String) -> Bool)? に変更
+[ ] 1-1: HotkeyManager.swift — extractUnicodeString(from:) を private static func として追加
+[ ] 1-1: HotkeyManager.swift — handleEvent で extractUnicodeString を呼び handler に渡す
+[ ] 1-2: HintModeController.swift — keyEventHandler の第3引数を _ で受け取るよう変更
+[ ] 1-3: ScrollModeController.swift — keyEventHandler の第3引数を _ で受け取るよう変更
+[ ] 1-4: SearchModeController.swift — keyEventHandler で unicodeString を第3引数として受け取る
+[ ] 1-4: SearchModeController.swift — handleKey シグネチャを handleKey(keyCode:flags:unicodeString:) に変更
+[ ] 1-4: SearchModeController.swift — keyCode 49 (Space) を確定条件から削除（Enter のみ確定）
+[ ] 1-4: SearchModeController.swift — 文字入力処理を keyCodeToChar() から unicodeString に切り替え
+[ ] 1-4: SearchModeController.swift — 印刷不可能文字フィルタ（scalar.value >= 32）を追加
+[ ] 1-4: SearchModeController.swift — keyCodeToChar() メソッドを削除
+[ ] Tests: SearchModeControllerTests.swift — filterWithUpperCaseQuery テスト追加
+[ ] Tests: SearchModeControllerTests.swift — filterWithSpaceInQuery テスト追加
+[ ] Tests: SearchModeControllerTests.swift — filterIsCaseInsensitiveForFullUpperCase テスト追加
+[ ] swift build 成功
+[ ] swift test 全テストパス
+[ ] 手動確認: 大文字入力（Shift+a → "A"）
+[ ] 手動確認: スペース入力（Space → " " がクエリに追加される）
+[ ] 手動確認: Enter のみ確定（Space は確定しない）
+[ ] 手動確認: HintMode / ScrollMode が従来どおり動作する
+
+--- Phase 2: 日本語 IME 対応 ---
+[ ] 2-1: OverlayWindow.swift — canBecomeKey を true で override
+[ ] 2-1: OverlayWindow.swift — showAsKeyWindow() メソッドを追加
+[ ] 2-1: OverlayWindow.swift — hide() に isKeyWindow チェック付き resignKey() を追加
+[ ] 2-2: SearchView.swift — SearchTextField (NSTextField サブクラス) を定義
+[ ] 2-2: SearchView.swift — SearchView に searchField プロパティを追加
+[ ] 2-2: SearchView.swift — setupTextField() で searchField を addSubview
+[ ] 2-2: SearchView.swift — NSTextFieldDelegate を実装し onQueryChanged コールバックを追加
+[ ] 2-2: SearchView.swift — focusSearchField() メソッドを追加
+[ ] 2-2: SearchView.swift — drawSearchBar() をテキスト描画から背景描画のみに変更
+[ ] 2-3: SearchModeController.swift — startSearchMode() で showAsKeyWindow() / focusSearchField() を呼ぶ
+[ ] 2-3: SearchModeController.swift — view.onQueryChanged に applyQuery を登録
+[ ] 2-3: SearchModeController.swift — keyEventHandler を ESC / Enter のみ処理に変更（他は return false）
+[ ] 2-3: SearchModeController.swift — handleControlKey() メソッドに分離
+[ ] 2-3: SearchModeController.swift — applyQuery() メソッドを追加
+[ ] 2-3: SearchModeController.swift — Phase 1 の handleKey(unicodeString:) を削除
+[ ] swift build 成功
+[ ] swift test 全テストパス（既存テスト変更なし）
+[ ] 手動確認: 日本語 IME 変換が機能する（ひらがな→漢字変換でフィルタ更新）
+[ ] 手動確認: 大文字・スペース入力が引き続き動作する
+[ ] 手動確認: Enter / ESC が正常に動作する
+[ ] 手動確認: HintMode / ScrollMode が従来どおり動作する（key window を奪わない）
+[ ] 手動確認: 検索モード終了後、元のアプリにフォーカスが戻る
+```


### PR DESCRIPTION
## Summary

- **日本語IME対応**: CGEventTapベースの入力からNSTextField + NSTextFieldDelegateに移行し、日本語・大文字・スペース入力に対応
- **IME変換確定Enterと検索Enterの区別**: `control(_:textView:doCommandBy:)` で `insertNewline` を検知し、IME変換中のEnterを検索実行と誤認しない設計
- **フローティング検索バーUI**: 画面下全体の黒帯から、画面中央下部の角丸フローティングバー（NSVisualEffectView + ブラー背景 + ドロップシャドウ）に刷新
- **アプリアクティベーション**: 検索モード起動時に `NSApp.activate` でVimursorをアクティブ化し、キーイベントがNSTextFieldに到達するよう修正。終了時は前アプリに復帰
- **検索対象要素の探索制限緩和**: depth 20→30、count 500→3000 に引き上げ、Notionサイドバー等の深いAXツリーに対応
- **サブエージェント権限**: `allowedTools`（旧形式）→ `permissions.allow`（現行形式）に修正

## Changed Files
- `HotkeyManager.swift` — keyEventHandler署名変更 + extractUnicodeString追加
- `SearchModeController.swift` — NSTextField委譲、アプリアクティベーション、executeSearch
- `SearchView.swift` — フローティングバーUI全面刷新（NSVisualEffectView, SearchTextField, countLabel）
- `OverlayWindow.swift` — canBecomeKey, showAsKeyWindow, ignoresMouseEvents制御
- `UIElementEnumerator.swift` — 探索制限緩和
- `HintModeController.swift` / `ScrollModeController.swift` — keyEventHandler第3引数対応
- `SearchModeControllerTests.swift` — 大文字・スペース・ケース非依存テスト追加

## Test plan
- [x] `swift build` 成功
- [x] `swift test` 全43テストパス
- [x] 検索モードで英字・大文字・スペース入力が動作すること
- [x] 日本語IMEで変換→確定→検索が正しく動作すること
- [x] フローティング検索バーが画面中央下部に角丸で表示されること
- [x] ESCで検索モードが終了し、前のアプリにフォーカスが戻ること
- [x] Notionサイドバー等の深い階層の要素が検索対象に含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Closes #17