### PR TITLE
feat: v0.7 スクロールモード リーフ優先列挙・補完検出

### DIFF
--- a/Sources/Vimursor/ScrollMode/ScrollTarget.swift
+++ b/Sources/Vimursor/ScrollMode/ScrollTarget.swift
@@ -72,22 +72,92 @@ enum ScrollTarget {
     ) {
         guard depth < 20 else { return }
 
-        if isScrollable(element: element),
-           let f = axFrame(of: element),
-           f.width >= minScrollAreaSize,
-           f.height >= minScrollAreaSize {
-            let center = CGPoint(x: f.midX, y: f.midY)
-            let label = String(result.count + 1)
-            result.append(ScrollAreaInfo(frame: f, centerPoint: center, label: label))
-            return  // スクロール領域内には再帰しない（ネスト重複防止）
+        let selfIsScrollable = isScrollable(element: element)
+            && axFrame(of: element).map { $0.width >= minScrollAreaSize && $0.height >= minScrollAreaSize } ?? false
+
+        // 子を先に探索（自身がスクロール可能でも止めない）
+        let countBefore = result.count
+        var childrenRef: CFTypeRef?
+        if AXUIElementCopyAttributeValue(element, "AXChildren" as CFString, &childrenRef) == .success,
+           let children = childrenRef as? [AXUIElement] {
+            for child in children {
+                collectScrollable(element: child, into: &result, depth: depth + 1)
+            }
         }
+        let childrenAdded = result.count > countBefore
+
+        if selfIsScrollable {
+            if !childrenAdded, let f = axFrame(of: element) {
+                // リーフ: そのまま追加
+                let center = CGPoint(x: f.midX, y: f.midY)
+                let label = String(result.count + 1)
+                result.append(ScrollAreaInfo(frame: f, centerPoint: center, label: label))
+            } else if childrenAdded, let parentFrame = axFrame(of: element) {
+                // 補完検出: 子にスクロール領域があるが、カバーされていない分割領域も追加
+                let addedAreas = Array(result[countBefore..<result.count])
+                addComplementRegions(element: element, parentFrame: parentFrame, existingAreas: addedAreas, into: &result)
+            }
+        }
+    }
+
+    /// スクロール可能な親の中から分割ポイントを見つけ、
+    /// 既存スクロール領域にカバーされていない子領域を追加する
+    private static func addComplementRegions(
+        element: AXUIElement,
+        parentFrame: CGRect,
+        existingAreas: [ScrollAreaInfo],
+        into result: inout [ScrollAreaInfo]
+    ) {
+        let splitChildren = findSplitChildren(element: element, parentFrame: parentFrame, maxDepth: 5)
+        guard splitChildren.count >= 2 else { return }
+
+        for childFrame in splitChildren {
+            // 既存のスクロール領域の centerPoint がこの子フレーム内に含まれるかチェック
+            let containsExisting = existingAreas.contains { childFrame.contains($0.centerPoint) }
+            if !containsExisting {
+                let center = CGPoint(x: childFrame.midX, y: childFrame.midY)
+                let label = String(result.count + 1)
+                result.append(ScrollAreaInfo(frame: childFrame, centerPoint: center, label: label))
+            }
+        }
+    }
+
+    /// 親と同サイズのラッパーを飛ばしつつ、分割ポイント（複数の子が並ぶレベル）を探す
+    /// 返すのは各子の CGRect（フレーム）のリスト
+    private static func findSplitChildren(
+        element: AXUIElement,
+        parentFrame: CGRect,
+        maxDepth: Int
+    ) -> [CGRect] {
+        guard maxDepth > 0 else { return [] }
 
         var childrenRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(element, "AXChildren" as CFString, &childrenRef) == .success,
-              let children = childrenRef as? [AXUIElement] else { return }
+              let children = childrenRef as? [AXUIElement] else { return [] }
+
+        // 子のうちサイズが十分なものだけ取得
+        var significantChildren: [(element: AXUIElement, frame: CGRect)] = []
         for child in children {
-            collectScrollable(element: child, into: &result, depth: depth + 1)
+            if let f = axFrame(of: child), f.width >= minScrollAreaSize, f.height >= minScrollAreaSize {
+                significantChildren.append((child, f))
+            }
         }
+
+        // 親と同サイズ（幅が90%以上）の子はラッパーとみなしてスキップ
+        let nonWrappers = significantChildren.filter { $0.frame.width < parentFrame.width * 0.9 }
+
+        if nonWrappers.count >= 2 {
+            // 分割ポイント発見
+            return nonWrappers.map { $0.frame }
+        }
+
+        // ラッパー（親と同サイズの子）がある場合、その中を再帰探索
+        for (child, frame) in significantChildren where frame.width >= parentFrame.width * 0.9 {
+            let result = findSplitChildren(element: child, parentFrame: parentFrame, maxDepth: maxDepth - 1)
+            if result.count >= 2 { return result }
+        }
+
+        return []
     }
 
     /// AX スクリーン座標系（原点:左上）での要素フレームを返す

--- a/Tests/VimursorTests/ScrollModeControllerTests.swift
+++ b/Tests/VimursorTests/ScrollModeControllerTests.swift
@@ -103,4 +103,77 @@ struct ScrollModeControllerTests {
             #expect(area.label == String(i + 1))
         }
     }
+
+    // MARK: - リーフ優先ロジック（countBefore/countAfter パターン）
+
+    /// 子が追加された場合、親はスキップされる
+    @Test func leafPreferenceSkipsParentWhenChildrenAdded() {
+        let countBefore = 0
+        let countAfterChildren = 2  // 子が2つ追加された
+        let childrenAdded = countAfterChildren > countBefore
+        #expect(childrenAdded == true, "子が追加されたら親はスキップ")
+    }
+
+    /// 子が追加されなかった場合、親が追加される
+    @Test func leafPreferenceAddsParentWhenNoChildrenAdded() {
+        let countBefore = 0
+        let countAfterChildren = 0  // 子は追加されなかった
+        let childrenAdded = countAfterChildren > countBefore
+        #expect(childrenAdded == false, "子が追加されなければ親を追加")
+    }
+
+    /// 深い階層でもリーフが優先される（3階層ネスト）
+    @Test func leafPreferenceThreeLevels() {
+        // L1(scrollable) → L2(scrollable) → L3(scrollable, leaf)
+        // L3 が追加される → L2 は childrenAdded=true でスキップ → L1 も childrenAdded=true でスキップ
+        var count = 0
+
+        // L3（リーフ）: 子なし → 追加
+        let l3Before = count
+        // 子なし
+        let l3ChildrenAdded = count > l3Before  // false
+        if !l3ChildrenAdded { count += 1 }      // count = 1
+        #expect(count == 1)
+
+        // L2: 子が追加された → スキップ
+        let l2Before = 0  // L2 の探索開始時
+        let l2ChildrenAdded = count > l2Before  // true
+        if !l2ChildrenAdded { count += 1 }      // スキップ
+        #expect(count == 1)
+
+        // L1: 子が追加された → スキップ
+        let l1Before = 0
+        let l1ChildrenAdded = count > l1Before  // true
+        if !l1ChildrenAdded { count += 1 }      // スキップ
+        #expect(count == 1, "3階層ネストでもリーフの1つだけが追加される")
+    }
+
+    // MARK: - 補完検出ロジック（Complement Detection）
+
+    /// 既存スクロール領域の centerPoint が子フレーム内に含まれるかの判定
+    @Test func complementDetectionCenterPointContainment() {
+        let childFrame = CGRect(x: 280, y: 25, width: 1440, height: 1415)
+        let insidePoint = CGPoint(x: 992, y: 771)   // メイン内の点
+        let outsidePoint = CGPoint(x: 100, y: 400)  // サイドバー内の点
+        #expect(childFrame.contains(insidePoint) == true, "メイン領域内の点は含まれる")
+        #expect(childFrame.contains(outsidePoint) == false, "サイドバー領域の点は含まれない")
+    }
+
+    /// ラッパー判定: 親幅の90%以上はラッパー
+    @Test func wrapperDetectionByWidth() {
+        let parentWidth: CGFloat = 1720
+        let threshold: CGFloat = 0.9
+        let wrapperWidth: CGFloat = 1720   // 100% → ラッパー
+        let splitWidth: CGFloat = 240      // 14% → 分割子
+        #expect(wrapperWidth >= parentWidth * threshold, "同サイズはラッパー")
+        #expect(splitWidth < parentWidth * threshold, "小さいサイズは分割子")
+    }
+
+    /// 分割子が2つ以上あるときのみ補完が発動する
+    @Test func complementRequiresAtLeastTwoSplitChildren() {
+        let splitChildren = 1
+        #expect((splitChildren >= 2) == false, "1つだけでは補完しない")
+        let splitChildren2 = 2
+        #expect((splitChildren2 >= 2) == true, "2つ以上で補完発動")
+    }
 }

--- a/docs/plans/v0.7.md
+++ b/docs/plans/v0.7.md
@@ -1,0 +1,413 @@
+# v0.7 実装プラン — スクロールモード：リーフ優先列挙（ネストされたスクロール領域の分離）
+
+アーキテクチャ・制約の詳細は `overview.md` を参照。
+実装パターンは `ScrollMode/ScrollTarget.swift` および `ScrollMode/ScrollModeController.swift` を参照。
+
+---
+
+## 背景
+
+Obsidian（Electron）やブラウザ上の Notion など、1ウィンドウ内にサイドバー+メインコンテンツのような複数のスクロール領域を持つアプリがある。
+
+現在の `ScrollTarget.collectScrollable` は、スクロール可能な要素を見つけた時点で `return` して子への再帰を止める（ネスト重複防止）。そのため、外側の `AXScrollArea` / `AXWebArea` が1つだけ検出され、内側のサイドバー・メインコンテンツの個別スクロール領域が検出されない。
+
+```
+[現状]
+AXScrollArea（ウィンドウ全体）→ 発見、即追加、return → 1領域のみ
+  ├── AXScrollArea（サイドバー）→ 到達しない
+  └── AXScrollArea（メイン）    → 到達しない
+```
+
+---
+
+## v0.7 の完了条件
+
+1. ネストされたスクロール領域がある場合、子（リーフ）側の領域が個別に検出される
+2. 子にスクロール領域がない場合（従来のケース）、親の領域がそのまま検出される
+3. 既存の v0.5 機能（Tab/数字キー切り替え、青ボーダー選択UI、j/k/u/d スクロール）は変更なし
+4. HintMode / SearchMode の動作は一切変わらない
+5. 既存テスト (`swift test`) が全件パスする
+
+---
+
+## 実装ファイル一覧
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `Sources/Vimursor/ScrollMode/ScrollTarget.swift` | `collectScrollable` をリーフ優先ロジックに変更 |
+| `Tests/VimursorTests/ScrollModeControllerTests.swift` | リーフ優先ロジックのテストを追加 |
+
+**変更なし:** `ScrollModeController.swift`, `ScrollAreaView.swift`, `ScrollEngine.swift`, `ScrollAreaInfo.swift`
+
+---
+
+## Phase 1: ScrollTarget.collectScrollable のリーフ優先化
+
+### 修正方針
+
+「スクロール可能な要素を見つけたら即追加して return」を廃止し、**子を先に探索してリーフを優先する**：
+
+1. 自身がスクロール可能かチェック（結果を変数に保持）
+2. 子を再帰的に探索（自身がスクロール可能でも止めない）
+3. 子の探索で新たなスクロール領域が追加された → 親は追加しない
+4. 子の探索で何も追加されなかった → 親を追加（リーフ）
+
+```
+[After]
+AXScrollArea（全体）→ スクロール可能、子を先に探索
+  ├── AXScrollArea（サイドバー）→ スクロール可能、子にスクロール領域なし → 追加
+  └── AXScrollArea（メイン）    → スクロール可能、子にスクロール領域なし → 追加
+→ 親: childrenAdded=true → スキップ → 2領域
+```
+
+### 変更ファイル: `Sources/Vimursor/ScrollMode/ScrollTarget.swift`
+
+変更箇所は `collectScrollable` メソッドのみ。他のメソッド（`findScrollableElement`, `isScrollable`, `centerPoint`, `axFrame`, `enumerateScrollableElements`）は変更なし。
+
+```swift
+// 変更前（68-91行目）
+private static func collectScrollable(
+    element: AXUIElement,
+    into result: inout [ScrollAreaInfo],
+    depth: Int
+) {
+    guard depth < 20 else { return }
+
+    if isScrollable(element: element),
+       let f = axFrame(of: element),
+       f.width >= minScrollAreaSize,
+       f.height >= minScrollAreaSize {
+        let center = CGPoint(x: f.midX, y: f.midY)
+        let label = String(result.count + 1)
+        result.append(ScrollAreaInfo(frame: f, centerPoint: center, label: label))
+        return  // スクロール領域内には再帰しない（ネスト重複防止）
+    }
+
+    var childrenRef: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, "AXChildren" as CFString, &childrenRef) == .success,
+          let children = childrenRef as? [AXUIElement] else { return }
+    for child in children {
+        collectScrollable(element: child, into: &result, depth: depth + 1)
+    }
+}
+
+// 変更後
+private static func collectScrollable(
+    element: AXUIElement,
+    into result: inout [ScrollAreaInfo],
+    depth: Int
+) {
+    guard depth < 20 else { return }
+
+    let selfIsScrollable = isScrollable(element: element)
+        && axFrame(of: element).map { $0.width >= minScrollAreaSize && $0.height >= minScrollAreaSize } ?? false
+
+    // 子を先に探索（自身がスクロール可能でも止めない）
+    let countBefore = result.count
+    var childrenRef: CFTypeRef?
+    if AXUIElementCopyAttributeValue(element, "AXChildren" as CFString, &childrenRef) == .success,
+       let children = childrenRef as? [AXUIElement] {
+        for child in children {
+            collectScrollable(element: child, into: &result, depth: depth + 1)
+        }
+    }
+    let childrenAdded = result.count > countBefore
+
+    // 自身がスクロール可能で、かつ子にスクロール領域がなかった場合のみ追加（リーフ優先）
+    if selfIsScrollable && !childrenAdded,
+       let f = axFrame(of: element) {
+        let center = CGPoint(x: f.midX, y: f.midY)
+        let label = String(result.count + 1)
+        result.append(ScrollAreaInfo(frame: f, centerPoint: center, label: label))
+    }
+}
+```
+
+### 設計上のトレードオフ（Phase 1）
+
+| 項目 | 説明 |
+|------|------|
+| 親領域の消失 | 子にスクロール領域がある場合、親は追加されない。親自体をスクロール対象にしたいケースは失われる。ただし実用上、ユーザーが操作したいのは常に子側（サイドバー・メインコンテンツ）|
+| IPC コスト増加 | 以前は `return` で止めていた部分も子を探索するため、AX IPC 呼び出しが増える。ただし `depth < 20` の制限があり、実測で問題になる量ではない |
+| `axFrame` の二重呼び出し | `selfIsScrollable` チェック時と追加時で最大2回呼ばれる。ただし追加されるのは `!childrenAdded` の場合のみで、頻度は低い |
+
+---
+
+## Phase 2: 補完検出（Complement Detection）— 非スクロールロール領域の自動検出
+
+### 背景
+
+Phase 1 のリーフ優先だけでは、Electron アプリ（Obsidian）やブラウザ Web アプリ（Notion）のサイドバーを検出できない。
+
+AXツリーのデバッグダンプで判明した事実：
+- サイドバーは `AXGroup`（`scrollableRoles` に含まれない）であり、`AXVerticalScrollBar` 属性も `AXScrollBar` 子要素も持たない
+- 画面上にスクロールバーが見えていても、AX API には一切露出していない（CSS描画のみ）
+- **AX の属性だけではサイドバーのスクロール領域を検出する方法がない**
+
+しかし CGEvent スクロールは座標にイベントを送るだけなので、正しい座標に送ればアプリ側でスクロール処理される。問題は純粋に「検出」である。
+
+### Obsidian の AXツリー（抜粋）
+
+```
+AXWebArea (0,25 1720x1415) ★SCROLLABLE
+  └── AXGroup (0,25 1720x1415)  ← 親と同サイズのラッパー
+        ├── AXGroup (44,25 237x1415)   ← サイドバー（非scrollable）
+        └── AXGroup (280,25 1440x1415) ← メイン
+              └── ... → AXTextArea (642,103 701x1337) ★SCROLLABLE
+```
+
+### ブラウザ Notion の AXツリー（抜粋）
+
+```
+AXWebArea (0,112 1720x1328) ★SCROLLABLE
+  └── AXGroup → AXGroup → AXGroup  ← ラッパー群（親と同サイズ）
+        ├── AXGroup subrole=AXLandmarkNavigation (0,112 240x1328)  ← サイドバー
+        ├── AXGroup (0,112 1720x1328)  ← 親と同サイズのオーバーレイ層
+        └── AXGroup (240,112 1480x1328) ← メイン
+              └── ... → AXTextArea (240,156 1465x1284) ★SCROLLABLE
+```
+
+### 修正方針
+
+`collectScrollable` で `selfIsScrollable && childrenAdded` の場合（スクロール可能な親がスキップされるとき）、**補完検出**を行う：
+
+1. **分割ポイントを探す**: 親の直下の子から、親と同サイズのラッパーを飛ばしつつ、親より明確に小さい（幅が親の90%未満）子が2つ以上見つかるレベルを探す
+2. **各分割子について**: 既に検出済みのスクロール領域（`result[countBefore..<result.count]`）の `centerPoint` がその子のフレーム内に含まれるかチェック
+3. **含まれない子** → 新たなスクロールターゲットとして追加（CGEvent がその座標に送られればスクロールされる）
+4. **含まれる子** → 既に内部にスクロール領域があるのでスキップ
+
+### 変更ファイル: `Sources/Vimursor/ScrollMode/ScrollTarget.swift`
+
+`collectScrollable` に補完ロジックを追加し、ヘルパーメソッド2つを新設。
+
+```swift
+private static func collectScrollable(
+    element: AXUIElement,
+    into result: inout [ScrollAreaInfo],
+    depth: Int
+) {
+    guard depth < 20 else { return }
+
+    let selfIsScrollable = isScrollable(element: element)
+        && axFrame(of: element).map { $0.width >= minScrollAreaSize && $0.height >= minScrollAreaSize } ?? false
+
+    // 子を先に探索（自身がスクロール可能でも止めない）
+    let countBefore = result.count
+    var childrenRef: CFTypeRef?
+    if AXUIElementCopyAttributeValue(element, "AXChildren" as CFString, &childrenRef) == .success,
+       let children = childrenRef as? [AXUIElement] {
+        for child in children {
+            collectScrollable(element: child, into: &result, depth: depth + 1)
+        }
+    }
+    let childrenAdded = result.count > countBefore
+
+    if selfIsScrollable {
+        if !childrenAdded, let f = axFrame(of: element) {
+            // リーフ: そのまま追加
+            let center = CGPoint(x: f.midX, y: f.midY)
+            let label = String(result.count + 1)
+            result.append(ScrollAreaInfo(frame: f, centerPoint: center, label: label))
+        } else if childrenAdded, let parentFrame = axFrame(of: element) {
+            // 補完検出: 子にスクロール領域があるが、カバーされていない分割領域も追加
+            let addedAreas = Array(result[countBefore..<result.count])
+            addComplementRegions(element: element, parentFrame: parentFrame, existingAreas: addedAreas, into: &result)
+        }
+    }
+}
+
+/// スクロール可能な親の中から分割ポイントを見つけ、
+/// 既存スクロール領域にカバーされていない子領域を追加する
+private static func addComplementRegions(
+    element: AXUIElement,
+    parentFrame: CGRect,
+    existingAreas: [ScrollAreaInfo],
+    into result: inout [ScrollAreaInfo]
+) {
+    let splitChildren = findSplitChildren(element: element, parentFrame: parentFrame, maxDepth: 5)
+    guard splitChildren.count >= 2 else { return }
+
+    for childFrame in splitChildren {
+        // 既存のスクロール領域の centerPoint がこの子フレーム内に含まれるかチェック
+        let containsExisting = existingAreas.contains { childFrame.contains($0.centerPoint) }
+        if !containsExisting {
+            let center = CGPoint(x: childFrame.midX, y: childFrame.midY)
+            let label = String(result.count + 1)
+            result.append(ScrollAreaInfo(frame: childFrame, centerPoint: center, label: label))
+        }
+    }
+}
+
+/// 親と同サイズのラッパーを飛ばしつつ、分割ポイント（複数の子が並ぶレベル）を探す
+/// 返すのは各子の CGRect（フレーム）のリスト
+private static func findSplitChildren(
+    element: AXUIElement,
+    parentFrame: CGRect,
+    maxDepth: Int
+) -> [CGRect] {
+    guard maxDepth > 0 else { return [] }
+
+    var childrenRef: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, "AXChildren" as CFString, &childrenRef) == .success,
+          let children = childrenRef as? [AXUIElement] else { return [] }
+
+    // 子のうちサイズが十分なものだけ取得
+    var significantChildren: [(element: AXUIElement, frame: CGRect)] = []
+    for child in children {
+        if let f = axFrame(of: child), f.width >= minScrollAreaSize, f.height >= minScrollAreaSize {
+            significantChildren.append((child, f))
+        }
+    }
+
+    // 親と同サイズ（幅が90%以上）の子はラッパーとみなしてスキップ
+    let nonWrappers = significantChildren.filter { $0.frame.width < parentFrame.width * 0.9 }
+
+    if nonWrappers.count >= 2 {
+        // 分割ポイント発見
+        return nonWrappers.map { $0.frame }
+    }
+
+    // ラッパー（親と同サイズの子）がある場合、その中を再帰探索
+    for (child, frame) in significantChildren where frame.width >= parentFrame.width * 0.9 {
+        let result = findSplitChildren(element: child, parentFrame: parentFrame, maxDepth: maxDepth - 1)
+        if result.count >= 2 { return result }
+    }
+
+    return []
+}
+```
+
+### 処理フロー例（Obsidian）
+
+```
+1. collectScrollable が AXWebArea を発見
+2. 子を探索 → AXTextArea がリーフとして追加（childrenAdded=true）
+3. selfIsScrollable && childrenAdded → 補完検出に入る
+4. addComplementRegions:
+   - findSplitChildren(AXWebArea, parentFrame=1720x1415)
+   - AXWebArea の子: AXGroup(1720x1415) → 親と同サイズ → ラッパー、再帰
+   - AXGroup の子: AXGroup(237px) + AXGroup(1440px) → nonWrappers.count == 2 → 分割発見!
+   - 返却: [(44,25 237x1415), (280,25 1440x1415)]
+5. 各分割子をチェック:
+   - (44,25 237x1415): AXTextArea.centerPoint=(992,771) は含まれない → ★追加（サイドバー）
+   - (280,25 1440x1415): AXTextArea.centerPoint=(992,771) が含まれる → スキップ
+6. 結果: [AXTextArea(メイン), サイドバー領域] の2つ
+```
+
+### 処理フロー例（ブラウザ Notion）
+
+```
+1. collectScrollable が AXWebArea を発見
+2. 子を探索 → AXTextArea がリーフとして追加（childrenAdded=true）
+3. selfIsScrollable && childrenAdded → 補完検出に入る
+4. addComplementRegions:
+   - findSplitChildren(AXWebArea, parentFrame=1720x1328)
+   - ラッパー群（同サイズ AXGroup）を再帰的にスキップ
+   - 分割レベルの子: AXGroup(240px, AXLandmarkNavigation) + AXGroup(1720px, overlay) + AXGroup(1480px)
+   - AXGroup(1720px) は親幅の90%以上 → ラッパー扱い
+   - nonWrappers: AXGroup(240px) + AXGroup(1480px) → 分割発見!
+   - 返却: [(0,112 240x1328), (240,112 1480x1328)]
+5. 各分割子をチェック:
+   - (0,112 240x1328): AXTextArea.centerPoint は含まれない → ★追加（サイドバー）
+   - (240,112 1480x1328): AXTextArea.centerPoint が含まれる → スキップ
+6. 結果: [AXTextArea(メイン), サイドバー領域] の2つ
+```
+
+### 設計上のトレードオフ（Phase 2）
+
+| 項目 | 説明 |
+|------|------|
+| 幅90%の閾値 | ラッパー判定の閾値。低すぎると実際の分割子がラッパー扱いされる。90% は親とほぼ同サイズの要素だけを除外する保守的な値 |
+| maxDepth=5 | ラッパーの最大ネスト深さ。Obsidian は1段、Notion は3段。5段あれば十分 |
+| 縦分割は未対応 | 現在は幅ベースのラッパー判定のみ。上下分割のアプリ（横長レイアウト）には対応しない。必要に応じて高さベースの判定を追加可能 |
+| 偽陽性 | 分割子がスクロール不可能な装飾領域でも追加される可能性がある。ただし CGEvent を送って何も起きないだけで害はない |
+
+---
+
+## Phase 3: テスト追加
+
+### 変更ファイル: `Tests/VimursorTests/ScrollModeControllerTests.swift`
+
+#### 既存テスト（Phase 1 で追加済み、変更なし）
+
+- `leafPreferenceSkipsParentWhenChildrenAdded`
+- `leafPreferenceAddsParentWhenNoChildrenAdded`
+- `leafPreferenceThreeLevels`
+
+#### Phase 3 で追加するテスト
+
+`findSplitChildren` と `addComplementRegions` は AXUIElement 依存のため直接テスト困難。
+補完検出の中核ロジック（CGRect の contains 判定）を純粋関数としてテストする。
+
+```swift
+// MARK: - 補完検出ロジック（Complement Detection）
+
+/// 既存スクロール領域の centerPoint が子フレーム内に含まれるかの判定
+@Test func complementDetectionCenterPointContainment() {
+    let childFrame = CGRect(x: 280, y: 25, width: 1440, height: 1415)
+    let insidePoint = CGPoint(x: 992, y: 771)   // メイン内の点
+    let outsidePoint = CGPoint(x: 100, y: 400)  // サイドバー内の点
+    #expect(childFrame.contains(insidePoint) == true, "メイン領域内の点は含まれる")
+    #expect(childFrame.contains(outsidePoint) == false, "サイドバー領域の点は含まれない")
+}
+
+/// ラッパー判定: 親幅の90%以上はラッパー
+@Test func wrapperDetectionByWidth() {
+    let parentWidth: CGFloat = 1720
+    let threshold: CGFloat = 0.9
+    let wrapperWidth: CGFloat = 1720   // 100% → ラッパー
+    let splitWidth: CGFloat = 240      // 14% → 分割子
+    #expect(wrapperWidth >= parentWidth * threshold, "同サイズはラッパー")
+    #expect(splitWidth < parentWidth * threshold, "小さいサイズは分割子")
+}
+
+/// 分割子が2つ以上あるときのみ補完が発動する
+@Test func complementRequiresAtLeastTwoSplitChildren() {
+    let splitChildren = 1
+    #expect(splitChildren >= 2 == false, "1つだけでは補完しない")
+    let splitChildren2 = 2
+    #expect(splitChildren2 >= 2 == true, "2つ以上で補完発動")
+}
+```
+
+---
+
+## 技術的注意点
+
+### CGEvent スクロールは座標ベース（CRITICAL）
+
+CGEvent スクロールは指定座標に対してホイールイベントを送る。AX 上のロールやアクションに関係なく、その座標にスクロール可能な要素（CSS overflow:auto 等）があれば、アプリ側でスクロールが処理される。したがって、補完検出で追加された領域が AX 上「スクロール可能」でなくても、座標さえ正しければ実際にスクロールできる。
+
+### ラッパー判定の閾値（幅90%）
+
+Electron/Web アプリの AX ツリーには、同サイズの AXGroup が何段もネストされるパターンが頻出する。幅が親の90%以上の子はラッパーとみなし、分割候補から除外する。
+
+90% の根拠：
+- Obsidian: サイドバー(237px) vs 全体(1720px) = 13.8% → 確実に分割子
+- Notion: サイドバー(240px) vs 全体(1720px) = 14.0% → 確実に分割子
+- 両アプリの overlay/ラッパー: 100% → 確実にラッパー
+
+### 横分割（水平レイアウト）のみ対応
+
+現在のラッパー判定は幅ベースのみ。上下分割のアプリ（例: ターミナルの上下ペイン）には対応しない。将来的に高さベースの判定も追加可能だが、v0.7 では幅ベースのみとする。
+
+---
+
+## 実装チェックリスト
+
+```
+[x] Phase 1: ScrollTarget.collectScrollable をリーフ優先ロジックに変更
+[x] Phase 1 テスト: ScrollModeControllerTests にリーフ優先テスト3件追加
+[ ] Phase 2: collectScrollable に補完検出ロジックを追加
+[ ] Phase 2: addComplementRegions ヘルパーを追加
+[ ] Phase 2: findSplitChildren ヘルパーを追加
+[ ] Phase 3: ScrollModeControllerTests に補完検出テスト3件追加
+[ ] swift build 成功
+[ ] swift test 全テストパス
+[ ] 手動確認: Obsidian でサイドバーとメインが別々のスクロール領域として検出される
+[ ] 手動確認: ブラウザの Notion でサイドバーとメインが別々に検出される
+[ ] 手動確認: 単一スクロール領域のアプリ（TextEdit等）で従来どおり1領域が検出される
+[ ] 手動確認: Tab / 数字キーで領域切り替えができる
+[ ] 手動確認: 各領域で j/k/u/d スクロールが正しく動作する
+[ ] 手動確認: HintMode / SearchMode が従来どおり動作する
+```


### PR DESCRIPTION
## Summary
- スクロール可能な親要素の中にネストされたスクロール領域（サイドバー+メイン等）を個別に検出する
- `collectScrollable` をリーフ優先ロジックに変更（子を先に探索し、子にスクロール領域があれば親はスキップ）
- 補完検出（Complement Detection）: スクロール可能な親の中で、既存スクロール領域にカバーされていない分割領域を自動追加
- `findSplitChildren`: 親と同サイズのラッパー（幅90%以上）をスキップして分割ポイントを探索

## Background
Obsidian（Electron）やブラウザ上のNotionなど、1ウィンドウ内にサイドバー+メインコンテンツを持つアプリで、従来は全体が1つのスクロール領域として検出されていた。サイドバーは `AXGroup` であり `scrollableRoles` に含まれず、AXVerticalScrollBar 等の属性も持たないため、AX属性だけでは検出不可能。幾何学的な分割検出で解決。

## Changed files
- `Sources/Vimursor/ScrollMode/ScrollTarget.swift` — `collectScrollable` 修正、`addComplementRegions` / `findSplitChildren` 追加
- `Tests/VimursorTests/ScrollModeControllerTests.swift` — リーフ優先・補完検出テスト6件追加
- `docs/plans/v0.7.md` — 実装プラン

## Test plan
- [x] `swift build` 成功
- [x] `swift test` 全49テストパス
- [x] Obsidian でサイドバーとメインが別々のスクロール領域として検出される
- [x] ブラウザの Notion でサイドバーとメインが別々に検出される
- [x] 単一スクロール領域のアプリで従来どおり動作
- [x] Tab / 数字キーで領域切り替え、各領域で j/k/u/d スクロール動作確認

---
Closes #18