### PR TITLE
feat: v0.8 Electron ヒントモード改善（AXManualAccessibility）

### DIFF
--- a/Sources/Vimursor/Accessibility/AXManager.swift
+++ b/Sources/Vimursor/Accessibility/AXManager.swift
@@ -106,12 +106,17 @@ final class AXManager: @unchecked Sendable {
     static func enableManualAccessibility() {
         guard let app = NSWorkspace.shared.frontmostApplication else { return }
         let appElement = AXUIElementCreateApplication(app.processIdentifier)
-        // 戻り値は無視（ネイティブアプリでは attributeUnsupported が返る）
-        AXUIElementSetAttributeValue(
+        let result = AXUIElementSetAttributeValue(
             appElement,
             "AXManualAccessibility" as CFString,
             true as CFTypeRef
         )
+        switch result {
+        case .success, .attributeUnsupported:
+            break
+        default:
+            NSLog("AXManager.enableManualAccessibility: AXUIElementSetAttributeValue failed with error: \(String(describing: result)) (rawValue: \(result.rawValue))")
+        }
     }
 
     /// NSWindow 座標系（原点:左下）の frame をスクリーン座標系（原点:左上）の中心点に変換する

--- a/Sources/Vimursor/Accessibility/AXManager.swift
+++ b/Sources/Vimursor/Accessibility/AXManager.swift
@@ -101,6 +101,19 @@ final class AXManager: @unchecked Sendable {
         up?.post(tap: .cghidEventTap)
     }
 
+    /// フォーカスアプリに AXManualAccessibility を設定し、Electron の完全な AX ツリーを有効にする。
+    /// ネイティブアプリでは attributeUnsupported が返るが、副作用なし。
+    static func enableManualAccessibility() {
+        guard let app = NSWorkspace.shared.frontmostApplication else { return }
+        let appElement = AXUIElementCreateApplication(app.processIdentifier)
+        // 戻り値は無視（ネイティブアプリでは attributeUnsupported が返る）
+        AXUIElementSetAttributeValue(
+            appElement,
+            "AXManualAccessibility" as CFString,
+            true as CFTypeRef
+        )
+    }
+
     /// NSWindow 座標系（原点:左下）の frame をスクリーン座標系（原点:左上）の中心点に変換する
     /// テスト用に static で公開
     static func centerScreenPoint(from frame: CGRect, screenHeight: CGFloat) -> CGPoint {

--- a/Sources/Vimursor/AppDelegate.swift
+++ b/Sources/Vimursor/AppDelegate.swift
@@ -29,6 +29,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                   let overlay = self.overlayWindow,
                   let hotkey = self.hotkeyManager,
                   hotkey.keyEventHandler == nil else { return }
+            AXManager.enableManualAccessibility()
             self.hintModeController?.activate(overlayWindow: overlay, hotkeyManager: hotkey)
         }
         manager.onSearchModeActivated = { [weak self] in

--- a/docs/plans/v0.8.md
+++ b/docs/plans/v0.8.md
@@ -117,7 +117,7 @@ manager.onHintModeActivated = { [weak self] in
 
 ### `@discardableResult` 不要
 
-`AXUIElementSetAttributeValue` の戻り値（`AXError`）を無視するが、Swift では C 関数の戻り値は暗黙的に破棄可能。`@discardableResult` アノテーションは不要。
+`AXUIElementSetAttributeValue` の戻り値（`AXError`）はこの呼び出しではあえて無視する。Swift から呼び出す C 関数でも、Clang 側に `warn_unused_result` などの注釈が付いている場合は未使用戻り値に警告が出るが、`AXUIElementSetAttributeValue` にはそのような注釈がないため、このケースでは警告にならない。必要に応じて `_ = AXUIElementSetAttributeValue(...)` のように明示的に破棄することもできるため、`@discardableResult` アノテーションは不要。
 
 ---
 

--- a/docs/plans/v0.8.md
+++ b/docs/plans/v0.8.md
@@ -1,0 +1,135 @@
+# v0.8 実装プラン — Electron アプリのヒントモード改善（AXManualAccessibility）
+
+アーキテクチャ・制約の詳細は `overview.md` を参照。
+実装パターンは `AppDelegate.swift` および `HintMode/HintModeController.swift` を参照。
+
+---
+
+## 背景
+
+Electron アプリ（Obsidian・VS Code 等）は、パフォーマンスのためデフォルトでは完全な AX ツリーを構築しない。VoiceOver 等のスクリーンリーダーが検出された場合にのみ有効化される。
+
+`AXManualAccessibility` 属性を外部から設定することで、Electron（Chromium）に対して「完全な AX ツリーを構築せよ」と指示できる。これにより、サイドバー内のボタン・リンク等がヒントモードで検出可能になる。
+
+### 実験結果
+
+| モード | AXManualAccessibility の効果 | 理由 |
+|--------|---------------------------|------|
+| **ヒントモード** | **効果あり** | `AXPress` アクションが露出され、クリック可能な要素が検出される |
+| **検索モード** | 効果なし | 要素は露出されても `title` / `description` 等のテキスト属性が空のまま |
+| **スクロールモード** | 効果なし | スクロール領域のロールが変わらない（v0.7 の幾何学的検出が引き続き有効） |
+
+---
+
+## v0.8 の完了条件
+
+1. ヒントモード起動時に、フォーカスアプリに対して `AXManualAccessibility` を設定する
+2. Obsidian のサイドバー要素にヒントラベルが表示され、クリックできる
+3. ネイティブアプリ（Finder・Safari 等）では従来どおり動作する（`AXManualAccessibility` は無害）
+4. 検索モード・スクロールモードの動作は一切変わらない
+5. 既存テスト (`swift test`) が全件パスする
+
+---
+
+## 実装ファイル一覧
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `Sources/Vimursor/Accessibility/AXManager.swift` | `enableManualAccessibility()` メソッド追加 |
+| `Sources/Vimursor/AppDelegate.swift` | ヒントモード起動前に `AXManager.enableManualAccessibility()` を呼び出し |
+
+**変更なし:** `HintModeController.swift`, `HotkeyManager.swift`, その他全ファイル
+
+---
+
+## Phase 1: AppDelegate に AXManualAccessibility ヘルパーを追加
+
+### 設計判断
+
+**スコープ: ヒントモードのみに適用**
+
+実験により検索モード・スクロールモードには効果がないことが確認済み。ヒントモード起動前にのみ呼ぶ。
+
+**呼び出しタイミング: 毎回のモード起動前**
+
+`AXUIElementSetAttributeValue` は冪等（何度呼んでも同じ結果）なので、毎回呼んでも害はない。アプリ切り替えを監視するより実装がシンプル。
+
+**エラーハンドリング: サイレントに無視**
+
+ネイティブアプリ等、`AXManualAccessibility` をサポートしない場合は `attributeUnsupported` が返る。これは期待される挙動であり、ログ出力やエラー表示は不要。
+
+### 変更ファイル: `Sources/Vimursor/Accessibility/AXManager.swift`
+
+AXUIElement 操作の責務は `AXManager` に集約する。
+
+```swift
+// 新規追加メソッド
+/// フォーカスアプリに AXManualAccessibility を設定し、Electron の完全な AX ツリーを有効にする。
+/// ネイティブアプリでは attributeUnsupported が返るが、副作用なし。
+static func enableManualAccessibility() {
+    guard let app = NSWorkspace.shared.frontmostApplication else { return }
+    let appElement = AXUIElementCreateApplication(app.processIdentifier)
+    // 戻り値は無視（ネイティブアプリでは attributeUnsupported が返る）
+    AXUIElementSetAttributeValue(
+        appElement,
+        "AXManualAccessibility" as CFString,
+        true as CFTypeRef
+    )
+}
+```
+
+### 変更ファイル: `Sources/Vimursor/AppDelegate.swift`
+
+```swift
+// ヒントモード起動コールバック内（変更箇所のみ）
+manager.onHintModeActivated = { [weak self] in
+    guard let self,
+          let overlay = self.overlayWindow,
+          let hotkey = self.hotkeyManager,
+          hotkey.keyEventHandler == nil else { return }
+    // Electron アプリの完全な AX ツリーを有効化
+    AXManager.enableManualAccessibility()
+    self.hintModeController?.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+}
+```
+
+### ネイティブアプリへの影響
+
+| アプリ種別 | `AXManualAccessibility` の挙動 |
+|-----------|------------------------------|
+| Electron アプリ（Obsidian, VS Code 等） | `success` — 完全な AX ツリーが構築される |
+| ネイティブアプリ（Finder, Safari 等） | `attributeUnsupported` — 何も起きない（既に完全な AX ツリーがある） |
+| Firefox, Spotify 等 | 未検証。`attributeUnsupported` になる可能性が高い |
+
+---
+
+## 技術的注意点
+
+### AXManualAccessibility の制約（CRITICAL）
+
+- **Electron バージョン依存**: Electron v28 以前では `kAXErrorAttributeUnsupported` で設定できないバグがあった（[#37465](https://github.com/electron/electron/issues/37465) で 2023年4月に修正済み）。古い Electron を使うアプリでは効果がない可能性がある
+- **パフォーマンス影響**: Electron 公式ドキュメントに「AX ツリーの構築はパフォーマンスに大きく影響する。デフォルトで有効にすべきではない」と記載。ただしヒントモード起動時に1回設定するだけなので、常時有効とは異なる
+- **一度設定すると永続**: アプリが終了するまで有効。`false` に戻すことも可能だが、ヒントモード終了時にわざわざ戻す必要はない（パフォーマンス影響は微小）
+
+### テスト方針
+
+`AXManager.enableManualAccessibility()` は `AXUIElementSetAttributeValue`（システムAPI）を直接呼ぶため、ユニットテストは対象外。既存テスト全件パスをもって完了とする。
+
+### `@discardableResult` 不要
+
+`AXUIElementSetAttributeValue` の戻り値（`AXError`）を無視するが、Swift では C 関数の戻り値は暗黙的に破棄可能。`@discardableResult` アノテーションは不要。
+
+---
+
+## 実装チェックリスト
+
+```
+[ ] AXManager.swift — enableManualAccessibility() メソッドを追加
+[ ] AppDelegate.swift — onHintModeActivated 内で AXManager.enableManualAccessibility() を呼ぶ
+[ ] swift build 成功
+[ ] swift test 全テストパス
+[ ] 手動確認: Obsidian のサイドバーにヒントラベルが表示される
+[ ] 手動確認: Obsidian のサイドバー要素をヒントで選択・クリックできる
+[ ] 手動確認: Finder / Safari 等のネイティブアプリで従来どおりヒントが動作する
+[ ] 手動確認: 検索モード・スクロールモードが従来どおり動作する
+```


### PR DESCRIPTION
## Summary

- ヒントモード起動時に `AXManualAccessibility` を設定することで、Electron アプリ（Obsidian・VS Code 等）の完全な AX ツリーを有効化
- `AXManager.enableManualAccessibility()` を追加し、AXUIElement 操作の責務を `AXManager` に集約
- ネイティブアプリ（Finder・Safari 等）では `attributeUnsupported` が返るため副作用なし

## Changes

- `Sources/Vimursor/Accessibility/AXManager.swift` — `enableManualAccessibility()` static メソッド追加
- `Sources/Vimursor/AppDelegate.swift` — `onHintModeActivated` 内、`activate()` 前に呼び出し追加
- `docs/plans/v0.8.md` — 実装プラン追加

## Test plan

- [x] `swift build` 成功
- [x] 手動確認: Obsidian のサイドバーにヒントラベルが表示される
- [x] 手動確認: Obsidian のサイドバー要素をヒントで選択・クリックできる
- [x] 手動確認: Finder / Safari 等のネイティブアプリで従来どおりヒントが動作する
- [x] 手動確認: 検索モード・スクロールモードが従来どおり動作する

---
Closes #19