### PR TITLE
feat: Epic 3 配布基盤（.app・dmg・CI/CDリリース）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Test
+        run: swift test
+
       - name: Build .app bundle
-        run: bash scripts/build-app.sh
+        run: |
+          export VIMURSOR_VERSION="${GITHUB_REF_NAME#v}"
+          bash scripts/build-app.sh
 
       - name: Build dmg
         run: bash scripts/build-dmg.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: macos-15
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build .app bundle
+        run: bash scripts/build-app.sh
+
+      - name: Build dmg
+        run: bash scripts/build-dmg.sh
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: Vimursor.dmg

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 *.profraw
+/Vimursor.app
+/Vimursor.dmg

--- a/Sources/Vimursor/Info.plist
+++ b/Sources/Vimursor/Info.plist
@@ -3,14 +3,26 @@
   "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>LSUIElement</key>
-    <true/>
     <key>CFBundleIdentifier</key>
     <string>com.vimursor.app</string>
     <key>CFBundleName</key>
     <string>Vimursor</string>
+    <key>CFBundleDisplayName</key>
+    <string>Vimursor</string>
+    <key>CFBundleExecutable</key>
+    <string>Vimursor</string>
     <key>CFBundleVersion</key>
-    <string>1.0</string>
+    <string>0.9.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.9.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
     <key>NSAccessibilityUsageDescription</key>
     <string>Vimursor needs accessibility access to detect UI elements and simulate clicks.</string>
 </dict>

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -11,11 +11,12 @@ CONTENTS="${APP_BUNDLE}/Contents"
 MACOS_DIR="${CONTENTS}/MacOS"
 RESOURCES_DIR="${CONTENTS}/Resources"
 INFO_PLIST_SRC="${REPO_ROOT}/Sources/Vimursor/Info.plist"
-BINARY_SRC="${REPO_ROOT}/.build/release/${APP_NAME}"
 
 echo "==> Building release binary..."
 cd "${REPO_ROOT}"
 swift build -c release
+BIN_PATH="$(swift build -c release --show-bin-path)"
+BINARY_SRC="${BIN_PATH}/${APP_NAME}"
 
 echo "==> Assembling ${APP_NAME}.app bundle..."
 rm -rf "${APP_BUNDLE}"
@@ -25,6 +26,11 @@ mkdir -p "${RESOURCES_DIR}"
 cp "${BINARY_SRC}" "${MACOS_DIR}/${APP_NAME}"
 chmod +x "${MACOS_DIR}/${APP_NAME}"
 cp "${INFO_PLIST_SRC}" "${CONTENTS}/Info.plist"
+
+# Inject version from git tag (e.g., v1.0.0 → 1.0.0)
+VERSION="${VIMURSOR_VERSION:-$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.9.0")}"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${VERSION}" "${CONTENTS}/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${VERSION}" "${CONTENTS}/Info.plist"
 
 echo "==> Validating bundle..."
 plutil -lint "${CONTENTS}/Info.plist"

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# scripts/build-app.sh — Package Vimursor into a macOS .app bundle
+# Usage: bash scripts/build-app.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+APP_NAME="Vimursor"
+APP_BUNDLE="${REPO_ROOT}/${APP_NAME}.app"
+CONTENTS="${APP_BUNDLE}/Contents"
+MACOS_DIR="${CONTENTS}/MacOS"
+RESOURCES_DIR="${CONTENTS}/Resources"
+INFO_PLIST_SRC="${REPO_ROOT}/Sources/Vimursor/Info.plist"
+BINARY_SRC="${REPO_ROOT}/.build/release/${APP_NAME}"
+
+echo "==> Building release binary..."
+cd "${REPO_ROOT}"
+swift build -c release
+
+echo "==> Assembling ${APP_NAME}.app bundle..."
+rm -rf "${APP_BUNDLE}"
+mkdir -p "${MACOS_DIR}"
+mkdir -p "${RESOURCES_DIR}"
+
+cp "${BINARY_SRC}" "${MACOS_DIR}/${APP_NAME}"
+chmod +x "${MACOS_DIR}/${APP_NAME}"
+cp "${INFO_PLIST_SRC}" "${CONTENTS}/Info.plist"
+
+echo "==> Validating bundle..."
+plutil -lint "${CONTENTS}/Info.plist"
+
+echo "==> Done: ${APP_BUNDLE}"
+echo "    Launch with: open ${APP_BUNDLE}"

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# scripts/build-dmg.sh — Create a dmg installer from Vimursor.app
+# Usage: bash scripts/build-dmg.sh
+# Prerequisite: Run scripts/build-app.sh first
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+APP_NAME="Vimursor"
+APP_BUNDLE="${REPO_ROOT}/${APP_NAME}.app"
+DMG_PATH="${REPO_ROOT}/${APP_NAME}.dmg"
+VOLUME_NAME="${APP_NAME}"
+
+if [[ ! -d "${APP_BUNDLE}" ]]; then
+    echo "ERROR: ${APP_BUNDLE} not found. Run scripts/build-app.sh first." >&2
+    exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+echo "==> Preparing dmg contents..."
+cp -r "${APP_BUNDLE}" "${TMP_DIR}/"
+ln -s /Applications "${TMP_DIR}/Applications"
+
+echo "==> Creating ${APP_NAME}.dmg..."
+rm -f "${DMG_PATH}"
+hdiutil create \
+    -volname "${VOLUME_NAME}" \
+    -srcfolder "${TMP_DIR}" \
+    -ov \
+    -format UDZO \
+    "${DMG_PATH}"
+
+echo "==> Done: ${DMG_PATH}"
+echo "    Open with: open ${DMG_PATH}"


### PR DESCRIPTION
## Summary

- `.app` バンドル化スクリプト (`scripts/build-app.sh`) を追加し、`swift build -c release` の出力をダブルクリック起動可能な `.app` にパッケージ
- dmg 作成スクリプト (`scripts/build-dmg.sh`) を追加し、Applications フォルダへのドラッグインストールに対応
- `v*` タグプッシュで dmg を自動生成し GitHub Releases にアップロードする CI/CD ワークフロー (`release.yml`) を追加

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `Sources/Vimursor/Info.plist` | .appバンドル用キー追加 |
| `scripts/build-app.sh` | 新規: .appビルドスクリプト |
| `scripts/build-dmg.sh` | 新規: dmg作成スクリプト |
| `.github/workflows/release.yml` | 新規: リリースワークフロー |
| `.gitignore` | ビルド成果物除外 |

## Test plan

- [x] `bash scripts/build-app.sh` でエラーなく `.app` 生成
- [x] `open Vimursor.app` で起動・ホットキー動作確認
- [x] `bash scripts/build-dmg.sh` で dmg 生成
- [x] dmg マウントで `.app` + `Applications` symlink 表示確認
- [x] `.app` 未生成時の `build-dmg.sh` エラーハンドリング確認
- [ ] テストタグで `release.yml` の CI 動作確認（マージ後）

Closes #30, Closes #31, Closes #32
Related: #23