### PR TITLE
feat: Epic 4 Onboarding・メニューバー

### DIFF
--- a/Sources/Vimursor/AccessibilityPermission/AccessibilityPermissionChecker.swift
+++ b/Sources/Vimursor/AccessibilityPermission/AccessibilityPermissionChecker.swift
@@ -12,6 +12,7 @@ protocol AccessibilityPermissionChecker {
 
 /// `AXIsProcessTrustedWithOptions` を使った本番実装。
 /// 権限確認ダイアログは表示しない（nil を渡す）。
+/// 代わりに AppDelegate.showPermissionAlert() でカスタム UI を提供する。
 struct SystemAccessibilityPermissionChecker: AccessibilityPermissionChecker {
     func isGranted() -> Bool {
         AXIsProcessTrustedWithOptions(nil)

--- a/Sources/Vimursor/AccessibilityPermission/AccessibilityPermissionChecker.swift
+++ b/Sources/Vimursor/AccessibilityPermission/AccessibilityPermissionChecker.swift
@@ -1,0 +1,19 @@
+import ApplicationServices
+
+// MARK: - Protocol
+
+/// アクセシビリティ権限の状態を問い合わせるプロトコル。
+/// テスト時にモックを差し込めるよう抽象化する。
+protocol AccessibilityPermissionChecker {
+    func isGranted() -> Bool
+}
+
+// MARK: - Production implementation
+
+/// `AXIsProcessTrustedWithOptions` を使った本番実装。
+/// 権限確認ダイアログは表示しない（nil を渡す）。
+struct SystemAccessibilityPermissionChecker: AccessibilityPermissionChecker {
+    func isGranted() -> Bool {
+        AXIsProcessTrustedWithOptions(nil)
+    }
+}

--- a/Sources/Vimursor/AccessibilityPermission/AccessibilityPermissionMonitor.swift
+++ b/Sources/Vimursor/AccessibilityPermission/AccessibilityPermissionMonitor.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+// MARK: - Monitor
+
+/// アクセシビリティ権限の付与をポーリングで監視するクラス。
+///
+/// `startPolling(onGranted:)` を呼ぶと指定間隔でチェックを行い、
+/// 権限が付与されたタイミングで `onGranted` を1度だけ呼び出す。
+/// `stopPolling()` でタイマーを停止できる。
+@MainActor
+final class AccessibilityPermissionMonitor {
+
+    // MARK: - Private properties
+
+    private let checker: any AccessibilityPermissionChecker
+    private let interval: TimeInterval
+    private var timer: Timer?
+    private var onGranted: (() -> Void)?
+
+    // MARK: - Initialization
+
+    /// - Parameters:
+    ///   - checker: 権限状態を問い合わせるプロバイダ
+    ///   - interval: ポーリング間隔（秒）。デフォルト 1.0 秒
+    init(checker: any AccessibilityPermissionChecker, interval: TimeInterval = 1.0) {
+        self.checker = checker
+        self.interval = interval
+    }
+
+    // NOTE: deinit では Timer の invalidate を行わない。
+    // Swift 6 の deinit は nonisolated であり、@MainActor プロパティへの直接アクセスは不可。
+    // MainActor.assumeIsolated はバックグラウンドスレッドからの解放時にクラッシュするリスクがある。
+    // 呼び出し側が不要になったタイミングで stopPolling() を呼ぶこと。
+
+    // MARK: - Public interface
+
+    /// ポーリングを開始する。権限が付与されたら `onGranted` を呼び出してタイマーを停止する。
+    /// すでにポーリング中の場合は先のタイマーを無効化してから再開する。
+    /// - Parameter onGranted: 権限付与検出時に **メインスレッド** で呼ばれるクロージャ
+    func startPolling(onGranted: @escaping () -> Void) {
+        stopPolling()
+        self.onGranted = onGranted
+
+        timer = Timer.scheduledTimer(
+            withTimeInterval: interval,
+            repeats: true
+        ) { [weak self] _ in
+            // Timer コールバックは @MainActor 外から来ることがあるため MainActor で実行
+            Task { @MainActor [weak self] in
+                self?.handleTimerFire()
+            }
+        }
+    }
+
+    /// ポーリングを停止する。
+    func stopPolling() {
+        timer?.invalidate()
+        timer = nil
+        onGranted = nil
+    }
+
+    // MARK: - Private
+
+    private func handleTimerFire() {
+        guard checker.isGranted() else { return }
+        // 権限付与を検出 — タイマーを先に停止してからコールバックを1度だけ呼ぶ
+        let callback = onGranted
+        stopPolling()
+        callback?()
+    }
+}

--- a/Sources/Vimursor/AppDelegate.swift
+++ b/Sources/Vimursor/AppDelegate.swift
@@ -7,6 +7,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hintModeController: HintModeController?
     private var searchModeController: SearchModeController?
     private var scrollModeController: ScrollModeController?
+    private var statusBarController: StatusBarController?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         checkAccessibilityPermission()
@@ -48,6 +49,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         self.hotkeyManager = manager
         manager.start()
+
+        self.statusBarController = StatusBarController(
+            onHintMode: { [weak self] in self?.hotkeyManager?.onHintModeActivated?() },
+            onSearchMode: { [weak self] in self?.hotkeyManager?.onSearchModeActivated?() },
+            onScrollMode: { [weak self] in self?.hotkeyManager?.onScrollModeActivated?() }
+        )
     }
 
     private func checkAccessibilityPermission() {

--- a/Sources/Vimursor/AppDelegate.swift
+++ b/Sources/Vimursor/AppDelegate.swift
@@ -8,22 +8,56 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var searchModeController: SearchModeController?
     private var scrollModeController: ScrollModeController?
     private var statusBarController: StatusBarController?
+    private var permissionMonitor: AccessibilityPermissionMonitor?
+    private var loginItemManager: LoginItemManager?
+
+    // MARK: - Constants
+
+    private enum AccessibilitySettings {
+        static let url = URL(
+            string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+        )
+    }
+
+    // MARK: - Lifecycle
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        checkAccessibilityPermission()
-
+        // UI構築（権限有無に関わらず常に実施）
         let overlay = OverlayWindow()
         self.overlayWindow = overlay
 
-        let hintController = HintModeController()
-        self.hintModeController = hintController
+        self.hintModeController = HintModeController()
+        self.searchModeController = SearchModeController()
+        self.scrollModeController = ScrollModeController()
 
-        let searchController = SearchModeController()
-        self.searchModeController = searchController
+        // ログイン時起動マネージャを生成し、システム状態と同期する
+        let loginManager = LoginItemManager()
+        loginManager.syncWithSystem()
+        self.loginItemManager = loginManager
 
-        let scrollController = ScrollModeController()
-        self.scrollModeController = scrollController
+        // メニューバーアイコンは権限に関わらず常に表示。
+        // モード起動コールバックは hotkeyManager が nil の場合は何もしない（weak self チェーンで自然に対応）。
+        self.statusBarController = StatusBarController(
+            onHintMode: { [weak self] in self?.hotkeyManager?.onHintModeActivated?() },
+            onSearchMode: { [weak self] in self?.hotkeyManager?.onSearchModeActivated?() },
+            onScrollMode: { [weak self] in self?.hotkeyManager?.onScrollModeActivated?() },
+            loginItemManager: loginManager
+        )
 
+        // 権限チェック → 許可済みなら即 setupHotkeyManager、未許可なら Alert + ポーリング
+        let checker = SystemAccessibilityPermissionChecker()
+        if checker.isGranted() {
+            setupHotkeyManager()
+        } else {
+            showPermissionAlert()
+            startPermissionPolling(checker: checker)
+        }
+    }
+
+    // MARK: - HotkeyManager setup
+
+    /// HotkeyManager を生成してコールバックを接続し、start() を呼ぶ。
+    private func setupHotkeyManager() {
         let manager = HotkeyManager()
         manager.onHintModeActivated = { [weak self] in
             guard let self,
@@ -49,26 +83,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         self.hotkeyManager = manager
         manager.start()
-
-        self.statusBarController = StatusBarController(
-            onHintMode: { [weak self] in self?.hotkeyManager?.onHintModeActivated?() },
-            onSearchMode: { [weak self] in self?.hotkeyManager?.onSearchModeActivated?() },
-            onScrollMode: { [weak self] in self?.hotkeyManager?.onScrollModeActivated?() }
-        )
     }
 
-    private func checkAccessibilityPermission() {
-        // kAXTrustedCheckOptionPrompt は C のグローバル var として Swift に見えるため
-        // Swift 6 strict concurrency 対策として生の文字列キーを使う
-        let options = ["AXTrustedCheckOptionPrompt": true] as CFDictionary
-        let trusted = AXIsProcessTrustedWithOptions(options)
-        if !trusted {
-            let alert = NSAlert()
-            alert.messageText = "アクセシビリティ権限が必要です"
-            alert.informativeText = "システム設定 > プライバシーとセキュリティ > アクセシビリティ で Vimursor を許可してください。"
-            alert.alertStyle = .warning
-            alert.addButton(withTitle: "OK")
-            alert.runModal()
+    // MARK: - Permission handling
+
+    /// 権限未許可時の NSAlert を表示し、どちらのボタン押下後もポーリングを開始する。
+    private func showPermissionAlert() {
+        let alert = NSAlert()
+        alert.messageText = "アクセシビリティ権限が必要です"
+        alert.informativeText = """
+            Vimursor はキーボード操作のためにアクセシビリティ権限が必要です。
+            システム設定 > プライバシーとセキュリティ > アクセシビリティ で許可してください。
+            """
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "システム設定を開く")
+        alert.addButton(withTitle: "後で")
+
+        let response = alert.runModal()
+        if response == .alertFirstButtonReturn,
+           let url = AccessibilitySettings.url {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    /// 権限付与を1秒間隔でポーリングし、付与されたら setupHotkeyManager() を呼ぶ。
+    private func startPermissionPolling(checker: some AccessibilityPermissionChecker) {
+        let monitor = AccessibilityPermissionMonitor(checker: checker, interval: 1.0)
+        self.permissionMonitor = monitor
+        monitor.startPolling { [weak self] in
+            self?.setupHotkeyManager()
+            self?.permissionMonitor = nil
         }
     }
 }

--- a/Sources/Vimursor/Info.plist
+++ b/Sources/Vimursor/Info.plist
@@ -23,6 +23,8 @@
     <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>LSUIElement</key>
+    <true/>
     <key>NSAccessibilityUsageDescription</key>
     <string>Vimursor needs accessibility access to detect UI elements and simulate clicks.</string>
 </dict>

--- a/Sources/Vimursor/LaunchAtLogin/LoginItemManager.swift
+++ b/Sources/Vimursor/LaunchAtLogin/LoginItemManager.swift
@@ -1,5 +1,8 @@
 import Foundation
 import ServiceManagement
+import os
+
+private let logger = Logger(subsystem: "com.vimursor.app", category: "LoginItem")
 
 // MARK: - Protocol
 
@@ -18,6 +21,7 @@ protocol LoginItemService {
 // MARK: - Production implementation
 
 /// SMAppService.mainApp をラップした本番用実装。
+@MainActor
 struct SMLoginItemService: LoginItemService {
     var isEnabled: Bool {
         SMAppService.mainApp.status == .enabled
@@ -85,7 +89,7 @@ final class LoginItemManager {
         } catch {
             // ロールバック: SMAppService 操作が失敗したため UserDefaults を元に戻す
             defaults.set(!newValue, forKey: LoginItemDefaultsKey.launchAtLogin)
-            print("[LoginItemManager] ログインアイテムの変更に失敗: \(error)")
+            logger.error("ログインアイテムの変更に失敗: \(error.localizedDescription)")
         }
     }
 

--- a/Sources/Vimursor/LaunchAtLogin/LoginItemManager.swift
+++ b/Sources/Vimursor/LaunchAtLogin/LoginItemManager.swift
@@ -1,0 +1,100 @@
+import Foundation
+import ServiceManagement
+
+// MARK: - Protocol
+
+/// ログインアイテム登録・解除の抽象化。
+/// 本番では SMAppService.mainApp をラップ、テストではモックを注入する。
+@MainActor
+protocol LoginItemService {
+    /// 現在のシステム登録状態を返す。
+    var isEnabled: Bool { get }
+    /// ログインアイテムに登録する。
+    func enable() throws
+    /// ログインアイテムから解除する。
+    func disable() throws
+}
+
+// MARK: - Production implementation
+
+/// SMAppService.mainApp をラップした本番用実装。
+struct SMLoginItemService: LoginItemService {
+    var isEnabled: Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+
+    func enable() throws {
+        try SMAppService.mainApp.register()
+    }
+
+    func disable() throws {
+        try SMAppService.mainApp.unregister()
+    }
+}
+
+// MARK: - Manager
+
+enum LoginItemDefaultsKey {
+    static let launchAtLogin = "launchAtLogin"
+}
+
+/// ログインアイテム登録の状態管理と UserDefaults 永続化を担当するクラス。
+/// toggle() 失敗時はロールバックを行い、ログを出力する。
+@MainActor
+final class LoginItemManager {
+
+    // MARK: - Private properties
+
+    private let service: any LoginItemService
+    private let defaults: UserDefaults
+
+    // MARK: - Public properties
+
+    /// UserDefaults に保存された「ログイン時起動」の状態。
+    var isEnabled: Bool {
+        defaults.bool(forKey: LoginItemDefaultsKey.launchAtLogin)
+    }
+
+    // MARK: - Initialization
+
+    /// 本番用イニシャライザ。SMLoginItemService を使う。
+    convenience init(defaults: UserDefaults = .standard) {
+        self.init(service: SMLoginItemService(), defaults: defaults)
+    }
+
+    /// テスト・DI 用イニシャライザ。任意の LoginItemService を注入できる。
+    init(service: any LoginItemService, defaults: UserDefaults = .standard) {
+        self.service = service
+        self.defaults = defaults
+    }
+
+    // MARK: - Public methods
+
+    /// ログイン時起動をトグルする。
+    /// UserDefaults を先に更新し、SMAppService への登録・解除を試みる。
+    /// 失敗した場合は UserDefaults をロールバックしてログを出力する。
+    func toggle() {
+        let newValue = !isEnabled
+        defaults.set(newValue, forKey: LoginItemDefaultsKey.launchAtLogin)
+        do {
+            if newValue {
+                try service.enable()
+            } else {
+                try service.disable()
+            }
+        } catch {
+            // ロールバック: SMAppService 操作が失敗したため UserDefaults を元に戻す
+            defaults.set(!newValue, forKey: LoginItemDefaultsKey.launchAtLogin)
+            print("[LoginItemManager] ログインアイテムの変更に失敗: \(error)")
+        }
+    }
+
+    /// SMAppService の実態と UserDefaults を同期する。
+    /// 起動時に呼び出し、外部での変更（システム設定での手動変更等）を反映する。
+    func syncWithSystem() {
+        let systemEnabled = service.isEnabled
+        if isEnabled != systemEnabled {
+            defaults.set(systemEnabled, forKey: LoginItemDefaultsKey.launchAtLogin)
+        }
+    }
+}

--- a/Sources/Vimursor/LaunchAtLogin/LoginItemManager.swift
+++ b/Sources/Vimursor/LaunchAtLogin/LoginItemManager.swift
@@ -75,9 +75,10 @@ final class LoginItemManager {
     // MARK: - Public methods
 
     /// ログイン時起動をトグルする。
-    /// UserDefaults を先に更新し、SMAppService への登録・解除を試みる。
-    /// 失敗した場合は UserDefaults をロールバックしてログを出力する。
+    /// まずシステム状態と同期してから反転し、SMAppService への登録・解除を試みる。
+    /// 失敗した場合は UserDefaults をシステム実態に再同期する。
     func toggle() {
+        syncWithSystem()
         let newValue = !isEnabled
         defaults.set(newValue, forKey: LoginItemDefaultsKey.launchAtLogin)
         do {
@@ -87,8 +88,8 @@ final class LoginItemManager {
                 try service.disable()
             }
         } catch {
-            // ロールバック: SMAppService 操作が失敗したため UserDefaults を元に戻す
-            defaults.set(!newValue, forKey: LoginItemDefaultsKey.launchAtLogin)
+            // ロールバック: SMAppService 操作が失敗したためシステム実態に再同期する
+            syncWithSystem()
             logger.error("ログインアイテムの変更に失敗: \(error.localizedDescription)")
         }
     }

--- a/Sources/Vimursor/StatusBarController.swift
+++ b/Sources/Vimursor/StatusBarController.swift
@@ -181,8 +181,14 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
     func menuWillOpen(_ menu: NSMenu) {
         if let item = menu.item(withTag: MenuItemTag.launchAtLogin) {
-            item.isEnabled = loginItemManager != nil
-            item.state = loginItemManager?.isEnabled == true ? .on : .off
+            if let loginItemManager {
+                loginItemManager.syncWithSystem()
+                item.isEnabled = true
+                item.state = loginItemManager.isEnabled ? .on : .off
+            } else {
+                item.isEnabled = false
+                item.state = .off
+            }
         }
     }
 

--- a/Sources/Vimursor/StatusBarController.swift
+++ b/Sources/Vimursor/StatusBarController.swift
@@ -1,4 +1,7 @@
 import AppKit
+import os
+
+private let logger = Logger(subsystem: "com.vimursor.app", category: "StatusBar")
 
 // MARK: - Constants
 
@@ -96,7 +99,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
             systemSymbolName: "keyboard",
             accessibilityDescription: "Vimursor"
         ) else {
-            print("[StatusBarController] SF Symbol 'keyboard' の読み込みに失敗しました")
+            logger.warning("SF Symbol 'keyboard' の読み込みに失敗しました")
             return
         }
         icon.isTemplate = true

--- a/Sources/Vimursor/StatusBarController.swift
+++ b/Sources/Vimursor/StatusBarController.swift
@@ -1,0 +1,188 @@
+import AppKit
+
+// MARK: - Protocol
+
+/// NSStatusItem のテスト用抽象化。
+/// 実装は NSStatusItem を直接ラップし、テストではモックを差し込む。
+@MainActor
+protocol StatusItemProvider: AnyObject {
+    var button: NSStatusBarButton? { get }
+    var menu: NSMenu? { get set }
+}
+
+// MARK: - Production wrapper
+
+/// NSStatusItem を StatusItemProvider として公開するラッパー。
+@MainActor
+final class SystemStatusItem: StatusItemProvider {
+    private let item: NSStatusItem
+
+    init() {
+        self.item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+    }
+
+    var button: NSStatusBarButton? { item.button }
+
+    var menu: NSMenu? {
+        get { item.menu }
+        set { item.menu = newValue }
+    }
+}
+
+// MARK: - Controller
+
+/// メニューバー常駐アイコンとメニューを管理するコントローラ。
+/// NSStatusItem のライフタイムを保持し、各モードの起動をコールバックに委譲する。
+@MainActor
+final class StatusBarController {
+
+    // MARK: - Private properties
+
+    private let statusItem: any StatusItemProvider
+    private let onHintMode: () -> Void
+    private let onSearchMode: () -> Void
+    private let onScrollMode: () -> Void
+
+    // MARK: - Initialization
+
+    /// 本番用イニシャライザ。NSStatusBar.system を使う。
+    convenience init(
+        onHintMode: @escaping () -> Void,
+        onSearchMode: @escaping () -> Void,
+        onScrollMode: @escaping () -> Void
+    ) {
+        self.init(
+            statusItem: SystemStatusItem(),
+            onHintMode: onHintMode,
+            onSearchMode: onSearchMode,
+            onScrollMode: onScrollMode
+        )
+    }
+
+    /// テスト・DI 用イニシャライザ。任意の StatusItemProvider を注入できる。
+    init(
+        statusItem: any StatusItemProvider,
+        onHintMode: @escaping () -> Void,
+        onSearchMode: @escaping () -> Void,
+        onScrollMode: @escaping () -> Void
+    ) {
+        self.statusItem = statusItem
+        self.onHintMode = onHintMode
+        self.onSearchMode = onSearchMode
+        self.onScrollMode = onScrollMode
+
+        configureButton()
+        configureMenu()
+    }
+
+    // MARK: - Private configuration
+
+    private func configureButton() {
+        guard let button = statusItem.button else { return }
+        guard let icon = NSImage(
+            systemSymbolName: "keyboard",
+            accessibilityDescription: "Vimursor"
+        ) else {
+            print("[StatusBarController] SF Symbol 'keyboard' の読み込みに失敗しました")
+            return
+        }
+        icon.isTemplate = true
+        button.image = icon
+        button.toolTip = "Vimursor"
+    }
+
+    private func configureMenu() {
+        let menu = NSMenu()
+
+        // ── モード起動 ──────────────────────────────
+        let hintItem = NSMenuItem(
+            title: "Hint Mode",
+            action: #selector(activateHintMode),
+            keyEquivalent: " "   // Space
+        )
+        hintItem.keyEquivalentModifierMask = [.command, .shift]
+        hintItem.target = self
+        menu.addItem(hintItem)
+
+        let searchItem = NSMenuItem(
+            title: "Search Mode",
+            action: #selector(activateSearchMode),
+            keyEquivalent: "?"
+        )
+        searchItem.keyEquivalentModifierMask = [.command]
+        searchItem.target = self
+        menu.addItem(searchItem)
+
+        let scrollItem = NSMenuItem(
+            title: "Scroll Mode",
+            action: #selector(activateScrollMode),
+            keyEquivalent: "j"
+        )
+        scrollItem.keyEquivalentModifierMask = [.command, .shift]
+        scrollItem.target = self
+        menu.addItem(scrollItem)
+
+        menu.addItem(.separator())
+
+        // ── About ─────────────────────────────────
+        let aboutItem = NSMenuItem(
+            title: "About Vimursor",
+            action: #selector(showAbout),
+            keyEquivalent: ""
+        )
+        aboutItem.target = self
+        menu.addItem(aboutItem)
+
+        menu.addItem(.separator())
+
+        // ── Quit ──────────────────────────────────
+        let quitItem = NSMenuItem(
+            title: "Quit Vimursor",
+            action: #selector(quitApp),
+            keyEquivalent: "q"
+        )
+        quitItem.keyEquivalentModifierMask = [.command]
+        quitItem.target = self
+        menu.addItem(quitItem)
+
+        statusItem.menu = menu
+    }
+
+    // MARK: - Menu actions
+
+    @objc private func activateHintMode() {
+        onHintMode()
+    }
+
+    @objc private func activateSearchMode() {
+        onSearchMode()
+    }
+
+    @objc private func activateScrollMode() {
+        onScrollMode()
+    }
+
+    @objc private func showAbout() {
+        NSApp.orderFrontStandardAboutPanel(nil)
+    }
+
+    @objc private func quitApp() {
+        NSApp.terminate(nil)
+    }
+
+    // MARK: - Test helpers
+
+    #if DEBUG
+    func simulateHintMode() {
+        onHintMode()
+    }
+
+    func simulateSearchMode() {
+        onSearchMode()
+    }
+
+    func simulateScrollMode() {
+        onScrollMode()
+    }
+    #endif
+}

--- a/Sources/Vimursor/StatusBarController.swift
+++ b/Sources/Vimursor/StatusBarController.swift
@@ -1,5 +1,11 @@
 import AppKit
 
+// MARK: - Constants
+
+private enum MenuItemTag {
+    static let launchAtLogin = 100
+}
+
 // MARK: - Protocol
 
 /// NSStatusItem のテスト用抽象化。
@@ -34,7 +40,7 @@ final class SystemStatusItem: StatusItemProvider {
 /// メニューバー常駐アイコンとメニューを管理するコントローラ。
 /// NSStatusItem のライフタイムを保持し、各モードの起動をコールバックに委譲する。
 @MainActor
-final class StatusBarController {
+final class StatusBarController: NSObject, NSMenuDelegate {
 
     // MARK: - Private properties
 
@@ -42,6 +48,7 @@ final class StatusBarController {
     private let onHintMode: () -> Void
     private let onSearchMode: () -> Void
     private let onScrollMode: () -> Void
+    private let loginItemManager: LoginItemManager?
 
     // MARK: - Initialization
 
@@ -49,13 +56,15 @@ final class StatusBarController {
     convenience init(
         onHintMode: @escaping () -> Void,
         onSearchMode: @escaping () -> Void,
-        onScrollMode: @escaping () -> Void
+        onScrollMode: @escaping () -> Void,
+        loginItemManager: LoginItemManager? = nil
     ) {
         self.init(
             statusItem: SystemStatusItem(),
             onHintMode: onHintMode,
             onSearchMode: onSearchMode,
-            onScrollMode: onScrollMode
+            onScrollMode: onScrollMode,
+            loginItemManager: loginItemManager
         )
     }
 
@@ -64,12 +73,16 @@ final class StatusBarController {
         statusItem: any StatusItemProvider,
         onHintMode: @escaping () -> Void,
         onSearchMode: @escaping () -> Void,
-        onScrollMode: @escaping () -> Void
+        onScrollMode: @escaping () -> Void,
+        loginItemManager: LoginItemManager? = nil
     ) {
         self.statusItem = statusItem
         self.onHintMode = onHintMode
         self.onSearchMode = onSearchMode
         self.onScrollMode = onScrollMode
+        self.loginItemManager = loginItemManager
+
+        super.init()
 
         configureButton()
         configureMenu()
@@ -135,6 +148,18 @@ final class StatusBarController {
 
         menu.addItem(.separator())
 
+        // ── Launch at Login ───────────────────────
+        let launchAtLoginItem = NSMenuItem(
+            title: "Launch at Login",
+            action: #selector(toggleLaunchAtLogin),
+            keyEquivalent: ""
+        )
+        launchAtLoginItem.target = self
+        launchAtLoginItem.tag = MenuItemTag.launchAtLogin
+        menu.addItem(launchAtLoginItem)
+
+        menu.addItem(.separator())
+
         // ── Quit ──────────────────────────────────
         let quitItem = NSMenuItem(
             title: "Quit Vimursor",
@@ -145,7 +170,17 @@ final class StatusBarController {
         quitItem.target = self
         menu.addItem(quitItem)
 
+        menu.delegate = self
         statusItem.menu = menu
+    }
+
+    // MARK: - NSMenuDelegate
+
+    func menuWillOpen(_ menu: NSMenu) {
+        if let item = menu.item(withTag: MenuItemTag.launchAtLogin) {
+            item.isEnabled = loginItemManager != nil
+            item.state = loginItemManager?.isEnabled == true ? .on : .off
+        }
     }
 
     // MARK: - Menu actions
@@ -164,6 +199,10 @@ final class StatusBarController {
 
     @objc private func showAbout() {
         NSApp.orderFrontStandardAboutPanel(nil)
+    }
+
+    @objc private func toggleLaunchAtLogin() {
+        loginItemManager?.toggle()
     }
 
     @objc private func quitApp() {

--- a/Sources/Vimursor/main.swift
+++ b/Sources/Vimursor/main.swift
@@ -1,7 +1,7 @@
 import AppKit
 
 let app = NSApplication.shared
-app.setActivationPolicy(.regular)
+app.setActivationPolicy(.accessory)
 let delegate = AppDelegate()
 app.delegate = delegate
 app.run()

--- a/Tests/VimursorTests/AccessibilityPermissionMonitorTests.swift
+++ b/Tests/VimursorTests/AccessibilityPermissionMonitorTests.swift
@@ -1,0 +1,110 @@
+import Testing
+import Foundation
+@testable import Vimursor
+
+// MARK: - Mock
+
+/// テスト用モック。isGranted() の戻り値を外部から制御できる。
+/// NOTE: granted を外部から書き換えて Monitor 内部に伝播させるため、
+/// 参照セマンティクスが必要。struct ではコピーされるため不可。
+final class MockAccessibilityPermissionChecker: AccessibilityPermissionChecker {
+    var granted: Bool
+
+    init(granted: Bool) {
+        self.granted = granted
+    }
+
+    func isGranted() -> Bool {
+        granted
+    }
+}
+
+// MARK: - Tests
+
+@Suite("AccessibilityPermissionMonitorTests")
+@MainActor
+struct AccessibilityPermissionMonitorTests {
+
+    // MARK: - startPolling: 初回から権限あり
+
+    @Test("権限が最初から付与済みならポーリング開始直後にコールバックが呼ばれること")
+    func callsOnGrantedImmediatelyWhenAlreadyGranted() async throws {
+        let checker = MockAccessibilityPermissionChecker(granted: true)
+        let monitor = AccessibilityPermissionMonitor(checker: checker, interval: 0.05)
+
+        var called = false
+        monitor.startPolling {
+            called = true
+        }
+
+        // Timer は RunLoop 経由なので少し待つ
+        try await Task.sleep(nanoseconds: 200_000_000) // 0.2s
+        monitor.stopPolling()
+
+        #expect(called == true)
+    }
+
+    // MARK: - startPolling: 権限なし → 後から付与
+
+    @Test("権限なし→付与でコールバックが呼ばれること")
+    func callsOnGrantedAfterPermissionIsGiven() async throws {
+        let checker = MockAccessibilityPermissionChecker(granted: false)
+        let monitor = AccessibilityPermissionMonitor(checker: checker, interval: 0.05)
+
+        var callCount = 0
+        monitor.startPolling {
+            callCount += 1
+        }
+
+        // 権限なしの間は呼ばれない
+        try await Task.sleep(nanoseconds: 100_000_000) // 0.1s
+        #expect(callCount == 0)
+
+        // 権限付与をシミュレート
+        checker.granted = true
+        try await Task.sleep(nanoseconds: 200_000_000) // 0.2s
+        monitor.stopPolling()
+
+        #expect(callCount == 1)
+    }
+
+    // MARK: - startPolling: コールバックは1度だけ
+
+    @Test("権限付与後にコールバックは1度だけ呼ばれること")
+    func callsOnGrantedOnlyOnce() async throws {
+        let checker = MockAccessibilityPermissionChecker(granted: true)
+        let monitor = AccessibilityPermissionMonitor(checker: checker, interval: 0.05)
+
+        var callCount = 0
+        monitor.startPolling {
+            callCount += 1
+        }
+
+        // 複数回ポーリングが走っても1度だけ
+        try await Task.sleep(nanoseconds: 300_000_000) // 0.3s
+        monitor.stopPolling()
+
+        #expect(callCount == 1)
+    }
+
+    // MARK: - stopPolling
+
+    @Test("stopPolling後はコールバックが呼ばれないこと")
+    func doesNotCallOnGrantedAfterStop() async throws {
+        let checker = MockAccessibilityPermissionChecker(granted: false)
+        let monitor = AccessibilityPermissionMonitor(checker: checker, interval: 0.05)
+
+        var callCount = 0
+        monitor.startPolling {
+            callCount += 1
+        }
+
+        monitor.stopPolling()
+
+        // 停止後に権限付与してもコールバックは呼ばれない
+        checker.granted = true
+        try await Task.sleep(nanoseconds: 200_000_000) // 0.2s
+
+        #expect(callCount == 0)
+    }
+}

--- a/Tests/VimursorTests/LoginItemManagerTests.swift
+++ b/Tests/VimursorTests/LoginItemManagerTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Testing
+@testable import Vimursor
+
+// MARK: - Mock
+
+/// LoginItemService のモック実装。
+/// class を使う理由: テスト内で enableCallCount / disableCallCount を変異させる必要があるため、
+/// 値型では #expect() 内のキャプチャが想定どおりに動作しない。
+/// @MainActor は不要 (プロトコル自体が @MainActor のため自動的に適用される)
+final class MockLoginItemService: LoginItemService {
+    var systemEnabled: Bool = false
+    var enableCallCount: Int = 0
+    var disableCallCount: Int = 0
+    var shouldThrowOnEnable: Bool = false
+    var shouldThrowOnDisable: Bool = false
+
+    var isEnabled: Bool { systemEnabled }
+
+    func enable() throws {
+        if shouldThrowOnEnable {
+            throw NSError(domain: "MockLoginItemService", code: 1, userInfo: [NSLocalizedDescriptionKey: "enable failed"])
+        }
+        enableCallCount += 1
+        systemEnabled = true
+    }
+
+    func disable() throws {
+        if shouldThrowOnDisable {
+            throw NSError(domain: "MockLoginItemService", code: 2, userInfo: [NSLocalizedDescriptionKey: "disable failed"])
+        }
+        disableCallCount += 1
+        systemEnabled = false
+    }
+}
+
+// MARK: - Tests
+
+@Suite("LoginItemManagerTests")
+struct LoginItemManagerTests {
+
+    // MARK: - toggle: ON
+
+    @Test("toggle() で OFF → ON になること")
+    @MainActor
+    func toggleEnablesLoginItem() {
+        let mockService = MockLoginItemService()
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let manager = LoginItemManager(service: mockService, defaults: defaults)
+
+        // 初期状態は OFF
+        #expect(manager.isEnabled == false)
+
+        manager.toggle()
+
+        #expect(manager.isEnabled == true)
+        #expect(mockService.enableCallCount == 1)
+        #expect(mockService.disableCallCount == 0)
+    }
+
+    // MARK: - toggle: OFF
+
+    @Test("toggle() で ON → OFF になること")
+    @MainActor
+    func toggleDisablesLoginItem() {
+        let mockService = MockLoginItemService()
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        defaults.set(true, forKey: LoginItemDefaultsKey.launchAtLogin)
+        let manager = LoginItemManager(service: mockService, defaults: defaults)
+
+        // 初期状態は ON
+        #expect(manager.isEnabled == true)
+
+        manager.toggle()
+
+        #expect(manager.isEnabled == false)
+        #expect(mockService.enableCallCount == 0)
+        #expect(mockService.disableCallCount == 1)
+    }
+
+    // MARK: - toggle: ロールバック（enable 失敗）
+
+    @Test("enable() が throw した場合は UserDefaults がロールバックされること")
+    @MainActor
+    func toggleRollsBackWhenEnableFails() {
+        let mockService = MockLoginItemService()
+        mockService.shouldThrowOnEnable = true
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let manager = LoginItemManager(service: mockService, defaults: defaults)
+
+        // 初期状態は OFF
+        #expect(manager.isEnabled == false)
+
+        manager.toggle()
+
+        // ロールバックにより OFF のまま
+        #expect(manager.isEnabled == false)
+        #expect(mockService.enableCallCount == 0)
+    }
+
+    // MARK: - toggle: ロールバック（disable 失敗）
+
+    @Test("disable() が throw した場合は UserDefaults がロールバックされること")
+    @MainActor
+    func toggleRollsBackWhenDisableFails() {
+        let mockService = MockLoginItemService()
+        mockService.shouldThrowOnDisable = true
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        defaults.set(true, forKey: LoginItemDefaultsKey.launchAtLogin)
+        let manager = LoginItemManager(service: mockService, defaults: defaults)
+
+        // 初期状態は ON
+        #expect(manager.isEnabled == true)
+
+        manager.toggle()
+
+        // ロールバックにより ON のまま
+        #expect(manager.isEnabled == true)
+        #expect(mockService.disableCallCount == 0)
+    }
+
+    // MARK: - syncWithSystem
+
+    @Test("syncWithSystem() でシステム状態が OFF なら UserDefaults が OFF に更新されること")
+    @MainActor
+    func syncWithSystemUpdatesDefaultsToFalse() {
+        let mockService = MockLoginItemService()
+        mockService.systemEnabled = false
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        // UserDefaults は ON、システムは OFF → 不整合
+        defaults.set(true, forKey: LoginItemDefaultsKey.launchAtLogin)
+        let manager = LoginItemManager(service: mockService, defaults: defaults)
+
+        manager.syncWithSystem()
+
+        #expect(manager.isEnabled == false)
+    }
+
+    @Test("syncWithSystem() でシステム状態が ON なら UserDefaults が ON に更新されること")
+    @MainActor
+    func syncWithSystemUpdatesDefaultsToTrue() {
+        let mockService = MockLoginItemService()
+        mockService.systemEnabled = true
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        // UserDefaults は OFF、システムは ON → 不整合
+        defaults.set(false, forKey: LoginItemDefaultsKey.launchAtLogin)
+        let manager = LoginItemManager(service: mockService, defaults: defaults)
+
+        manager.syncWithSystem()
+
+        #expect(manager.isEnabled == true)
+    }
+
+    @Test("syncWithSystem() で状態が一致していれば UserDefaults は変更されないこと")
+    @MainActor
+    func syncWithSystemDoesNotChangeDefaultsWhenAlreadyInSync() {
+        let mockService = MockLoginItemService()
+        mockService.systemEnabled = true
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        defaults.set(true, forKey: LoginItemDefaultsKey.launchAtLogin)
+        let manager = LoginItemManager(service: mockService, defaults: defaults)
+
+        manager.syncWithSystem()
+
+        #expect(manager.isEnabled == true)
+    }
+
+    // MARK: - isEnabled デフォルト値
+
+    @Test("isEnabled のデフォルト値は false であること")
+    @MainActor
+    func isEnabledDefaultsToFalse() {
+        let mockService = MockLoginItemService()
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let manager = LoginItemManager(service: mockService, defaults: defaults)
+
+        #expect(manager.isEnabled == false)
+    }
+}

--- a/Tests/VimursorTests/LoginItemManagerTests.swift
+++ b/Tests/VimursorTests/LoginItemManagerTests.swift
@@ -64,6 +64,7 @@ struct LoginItemManagerTests {
     @MainActor
     func toggleDisablesLoginItem() {
         let mockService = MockLoginItemService()
+        mockService.systemEnabled = true
         let defaults = UserDefaults(suiteName: UUID().uuidString)!
         defaults.set(true, forKey: LoginItemDefaultsKey.launchAtLogin)
         let manager = LoginItemManager(service: mockService, defaults: defaults)
@@ -104,6 +105,7 @@ struct LoginItemManagerTests {
     @MainActor
     func toggleRollsBackWhenDisableFails() {
         let mockService = MockLoginItemService()
+        mockService.systemEnabled = true
         mockService.shouldThrowOnDisable = true
         let defaults = UserDefaults(suiteName: UUID().uuidString)!
         defaults.set(true, forKey: LoginItemDefaultsKey.launchAtLogin)

--- a/Tests/VimursorTests/StatusBarControllerTests.swift
+++ b/Tests/VimursorTests/StatusBarControllerTests.swift
@@ -86,8 +86,9 @@ struct StatusBarControllerTests {
             onSearchMode: {},
             onScrollMode: {}
         )
-        // Hint Mode, Search Mode, Scroll Mode, separator, About, separator, Quit = 7 items
-        #expect(mockItem.menu?.items.count == 7)
+        // Hint Mode, Search Mode, Scroll Mode, separator, About, separator,
+        // Launch at Login, separator, Quit = 9 items
+        #expect(mockItem.menu?.items.count == 9)
     }
 
     @Test("メニュータイトルが正しいこと")
@@ -105,6 +106,7 @@ struct StatusBarControllerTests {
         #expect(titles.contains("Search Mode"))
         #expect(titles.contains("Scroll Mode"))
         #expect(titles.contains("About Vimursor"))
+        #expect(titles.contains("Launch at Login"))
         #expect(titles.contains("Quit Vimursor"))
     }
 }

--- a/Tests/VimursorTests/StatusBarControllerTests.swift
+++ b/Tests/VimursorTests/StatusBarControllerTests.swift
@@ -1,0 +1,110 @@
+import AppKit
+import Testing
+@testable import Vimursor
+
+// MARK: - Mock
+
+/// NSStatusBar を呼ばずに StatusBarController をテストするためのモック。
+@MainActor
+final class MockStatusItem: StatusItemProvider {
+    var button: NSStatusBarButton? { nil }
+    var menu: NSMenu?
+}
+
+// MARK: - Tests
+
+@Suite("StatusBarControllerTests")
+struct StatusBarControllerTests {
+
+    @Test("onHintMode クロージャが呼ばれること")
+    @MainActor
+    func hintModeCallbackIsInvoked() {
+        var hintCalled = false
+        var searchCalled = false
+        var scrollCalled = false
+
+        let controller = StatusBarController(
+            statusItem: MockStatusItem(),
+            onHintMode: { hintCalled = true },
+            onSearchMode: { searchCalled = true },
+            onScrollMode: { scrollCalled = true }
+        )
+
+        controller.simulateHintMode()
+        #expect(hintCalled == true)
+        #expect(searchCalled == false)
+        #expect(scrollCalled == false)
+    }
+
+    @Test("onSearchMode クロージャが呼ばれること")
+    @MainActor
+    func searchModeCallbackIsInvoked() {
+        var hintCalled = false
+        var searchCalled = false
+        var scrollCalled = false
+
+        let controller = StatusBarController(
+            statusItem: MockStatusItem(),
+            onHintMode: { hintCalled = true },
+            onSearchMode: { searchCalled = true },
+            onScrollMode: { scrollCalled = true }
+        )
+
+        controller.simulateSearchMode()
+        #expect(hintCalled == false)
+        #expect(searchCalled == true)
+        #expect(scrollCalled == false)
+    }
+
+    @Test("onScrollMode クロージャが呼ばれること")
+    @MainActor
+    func scrollModeCallbackIsInvoked() {
+        var hintCalled = false
+        var searchCalled = false
+        var scrollCalled = false
+
+        let controller = StatusBarController(
+            statusItem: MockStatusItem(),
+            onHintMode: { hintCalled = true },
+            onSearchMode: { searchCalled = true },
+            onScrollMode: { scrollCalled = true }
+        )
+
+        controller.simulateScrollMode()
+        #expect(hintCalled == false)
+        #expect(searchCalled == false)
+        #expect(scrollCalled == true)
+    }
+
+    @Test("メニューが正しい項目数を持つこと")
+    @MainActor
+    func menuHasCorrectItemCount() {
+        let mockItem = MockStatusItem()
+        _ = StatusBarController(
+            statusItem: mockItem,
+            onHintMode: {},
+            onSearchMode: {},
+            onScrollMode: {}
+        )
+        // Hint Mode, Search Mode, Scroll Mode, separator, About, separator, Quit = 7 items
+        #expect(mockItem.menu?.items.count == 7)
+    }
+
+    @Test("メニュータイトルが正しいこと")
+    @MainActor
+    func menuItemTitlesAreCorrect() {
+        let mockItem = MockStatusItem()
+        _ = StatusBarController(
+            statusItem: mockItem,
+            onHintMode: {},
+            onSearchMode: {},
+            onScrollMode: {}
+        )
+        let titles = mockItem.menu?.items.map(\.title) ?? []
+        #expect(titles.contains("Hint Mode"))
+        #expect(titles.contains("Search Mode"))
+        #expect(titles.contains("Scroll Mode"))
+        #expect(titles.contains("About Vimursor"))
+        #expect(titles.contains("Quit Vimursor"))
+    }
+}

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -32,6 +32,10 @@ VERSION="${VIMURSOR_VERSION:-$(git describe --tags --abbrev=0 2>/dev/null | sed 
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${VERSION}" "${CONTENTS}/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${VERSION}" "${CONTENTS}/Info.plist"
 
+echo "==> Signing bundle (ad-hoc)..."
+xattr -cr "${APP_BUNDLE}"
+codesign -s - -f --deep "${APP_BUNDLE}"
+
 echo "==> Validating bundle..."
 plutil -lint "${CONTENTS}/Info.plist"
 


### PR DESCRIPTION
## Summary

アプリとしての入口を整備。メニューバー常駐化・アクセシビリティ権限案内UI・ログイン時自動起動を実装。

- **[4-1] メニューバー常駐化** (#36): `NSStatusItem` でメニューバーにアイコン常駐、`setActivationPolicy(.accessory)` で Dock 非表示
- **[4-2] アクセシビリティ権限の案内UI改善** (#37): 「システム設定を開く」ボタン付きダイアログ、ポーリングによる権限付与自動検出
- **[4-3] ログイン時自動起動** (#38): `SMAppService` によるログインアイテム登録、メニューからの ON/OFF トグル

## Changes

### 新規ファイル
- `Sources/Vimursor/StatusBarController.swift` — メニューバーアイコン・メニュー管理
- `Sources/Vimursor/AccessibilityPermission/AccessibilityPermissionChecker.swift` — 権限チェック抽象化
- `Sources/Vimursor/AccessibilityPermission/AccessibilityPermissionMonitor.swift` — 権限ポーリング
- `Sources/Vimursor/LaunchAtLogin/LoginItemManager.swift` — ログインアイテム管理
- `Tests/VimursorTests/StatusBarControllerTests.swift` — 5テスト
- `Tests/VimursorTests/AccessibilityPermissionMonitorTests.swift` — 4テスト
- `Tests/VimursorTests/LoginItemManagerTests.swift` — 8テスト

### 変更ファイル
- `Sources/Vimursor/main.swift` — `.regular` → `.accessory`
- `Sources/Vimursor/AppDelegate.swift` — 権限フロー改善・StatusBarController/LoginItemManager 組み込み
- `Sources/Vimursor/Info.plist` — `LSUIElement` 追加
- `scripts/build-app.sh` — アドホックコード署名ステップ追加

## Test plan
- [x] `swift build` / `swift test` PASS（66テスト全通過）
- [x] メニューバーにアイコンが表示される
- [x] メニューから各モード（Hint/Search/Scroll）が起動する
- [x] 既存ホットキー（⌘⇧Space / ⌘⇧/ / ⌘⇧J）が正常動作
- [x] 権限未許可時に案内ダイアログが表示される
- [x] 権限付与後、再起動なしにホットキーが有効化される
- [x] 「Launch at Login」トグルが動作する（.app バンドル + コード署名時）
- [x] Dock にアイコンが表示されない

## Related Issues
- Epic: #24
- Closes #36, #37, #38
- Related: #39 (Search Mode の keyEquivalent 表示問題、既知の制限)

🤖 Generated with [Claude Code](https://claude.com/claude-code)