### PR TITLE
feat: Epic 5 ヒントモード連続機能（Copilotレビュー修正込み）

### DIFF
--- a/Sources/Vimursor/AppDelegate.swift
+++ b/Sources/Vimursor/AppDelegate.swift
@@ -10,6 +10,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusBarController: StatusBarController?
     private var permissionMonitor: AccessibilityPermissionMonitor?
     private var loginItemManager: LoginItemManager?
+    private var hintModeSettings: HintModeSettings?
 
     // MARK: - Constants
 
@@ -26,7 +27,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let overlay = OverlayWindow()
         self.overlayWindow = overlay
 
-        self.hintModeController = HintModeController()
+        let hintSettings = HintModeSettings()
+        self.hintModeSettings = hintSettings
+        self.hintModeController = HintModeController(settings: hintSettings)
         self.searchModeController = SearchModeController()
         self.scrollModeController = ScrollModeController()
 
@@ -41,7 +44,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             onHintMode: { [weak self] in self?.hotkeyManager?.onHintModeActivated?() },
             onSearchMode: { [weak self] in self?.hotkeyManager?.onSearchModeActivated?() },
             onScrollMode: { [weak self] in self?.hotkeyManager?.onScrollModeActivated?() },
-            loginItemManager: loginManager
+            loginItemManager: loginManager,
+            hintModeSettings: hintSettings
         )
 
         // 権限チェック → 許可済みなら即 setupHotkeyManager、未許可なら Alert + ポーリング

--- a/Sources/Vimursor/HintMode/HintModeController.swift
+++ b/Sources/Vimursor/HintMode/HintModeController.swift
@@ -4,6 +4,11 @@ private enum HintModeState {
     case inactive
     case fetching   // 要素取得中。この状態でも activate() を弾く
     case active(hints: [UIElementInfo], input: String)
+    case restarting // クリック後〜再起動待ち。ESC のみ受付
+}
+
+private enum HintKeyCode {
+    static let esc: CGKeyCode = 53
 }
 
 // CGEventTapスレッドからアクティブ状態だけを読めるよう分離
@@ -15,6 +20,15 @@ final class HintModeController {
     private var hintView: HintView?
     private weak var overlayWindow: OverlayWindow?
     private weak var hotkeyManager: HotkeyManager?
+    private let settings: HintModeSettings
+
+    static let reactivationDelay: TimeInterval = 0.3
+    static let clickDelay: TimeInterval = 0.05
+    private(set) var reactivationTask: Task<Void, Never>?
+
+    init(settings: HintModeSettings) {
+        self.settings = settings
+    }
 
     func activate(overlayWindow: OverlayWindow, hotkeyManager: HotkeyManager) {
         guard case .inactive = state else { return }  // fetching / active 中はスキップ
@@ -70,6 +84,8 @@ final class HintModeController {
     }
 
     func deactivate() {
+        reactivationTask?.cancel()
+        reactivationTask = nil
         state = .inactive
         hintView?.removeFromSuperview()
         hintView = nil
@@ -78,10 +94,15 @@ final class HintModeController {
     }
 
     private func handleKey(keyCode: CGKeyCode, flags: CGEventFlags) {
+        if case .restarting = state {
+            if keyCode == HintKeyCode.esc { deactivate() }  // ESC のみ受付
+            return  // 他のキーは消費して無視
+        }
+
         guard case .active(let hints, let input) = state else { return }
 
         // ESC
-        if keyCode == 53 {
+        if keyCode == HintKeyCode.esc {
             deactivate()
             return
         }
@@ -101,15 +122,63 @@ final class HintModeController {
 
         if let exact = matches.first(where: { $0.label == newInput }) {
             let frame = exact.frame
-            deactivate()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
-                self?.axManager.clickAt(frame: frame)
+            if settings.isContinuousMode {
+                enterRestartingState()
+                Task { @MainActor [weak self] in
+                    do {
+                        try await Task.sleep(for: .seconds(Self.clickDelay))
+                    } catch is CancellationError {
+                        return
+                    }
+                    guard let self else { return }
+                    guard case .restarting = self.state else { return }  // ESCでdeactivateされていたら中断
+                    self.axManager.clickAt(frame: frame)
+                    self.scheduleReactivation()
+                }
+            } else {
+                // 単発モード: オーバーレイ非表示後にクリック送信（連続モードの enterRestartingState と同等の順序）
+                deactivate()
+                Task { @MainActor [weak self] in
+                    do {
+                        try await Task.sleep(for: .seconds(Self.clickDelay))
+                    } catch is CancellationError {
+                        return
+                    }
+                    self?.axManager.clickAt(frame: frame)
+                }
             }
             return
         }
 
         state = .active(hints: hints, input: newInput)
         hintView?.update(hints: hints, inputPrefix: newInput)
+    }
+
+    private func enterRestartingState() {
+        state = .restarting
+        hintView?.removeFromSuperview()
+        hintView = nil
+        overlayWindow?.hide()
+        // keyEventHandler は維持（ホットキー誤発火防止 + ESC 受付）
+    }
+
+    private func scheduleReactivation() {
+        reactivationTask = Task<Void, Never> { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await Task.sleep(for: .seconds(Self.reactivationDelay))
+            } catch {
+                return  // CancellationError（Task.sleepの唯一のエラー）
+            }
+            guard case .restarting = self.state else { return }
+            self.reactivationTask = nil
+            self.state = .inactive
+            if let overlay = self.overlayWindow, let hotkey = self.hotkeyManager {
+                self.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+            } else {
+                self.hotkeyManager?.keyEventHandler = nil  // weak ref 解放時の孤立ハンドラ防止
+            }
+        }
     }
 
     private func keyCodeToChar(_ keyCode: CGKeyCode) -> String? {

--- a/Sources/Vimursor/HintMode/HintModeSettings.swift
+++ b/Sources/Vimursor/HintMode/HintModeSettings.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum HintModeDefaultsKey {
+    static let continuousMode = "hintMode.continuousMode"
+}
+
+struct HintModeSettings {
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        defaults.register(defaults: [HintModeDefaultsKey.continuousMode: true])
+    }
+
+    var isContinuousMode: Bool {
+        defaults.bool(forKey: HintModeDefaultsKey.continuousMode)
+    }
+
+    func toggle() {
+        defaults.set(!isContinuousMode, forKey: HintModeDefaultsKey.continuousMode)
+    }
+}

--- a/Sources/Vimursor/StatusBarController.swift
+++ b/Sources/Vimursor/StatusBarController.swift
@@ -7,6 +7,7 @@ private let logger = Logger(subsystem: "com.vimursor.app", category: "StatusBar"
 
 private enum MenuItemTag {
     static let launchAtLogin = 100
+    static let continuousHintMode = 101
 }
 
 // MARK: - Protocol
@@ -52,6 +53,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     private let onSearchMode: () -> Void
     private let onScrollMode: () -> Void
     private let loginItemManager: LoginItemManager?
+    private let hintModeSettings: HintModeSettings
 
     // MARK: - Initialization
 
@@ -60,14 +62,16 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         onHintMode: @escaping () -> Void,
         onSearchMode: @escaping () -> Void,
         onScrollMode: @escaping () -> Void,
-        loginItemManager: LoginItemManager? = nil
+        loginItemManager: LoginItemManager? = nil,
+        hintModeSettings: HintModeSettings
     ) {
         self.init(
             statusItem: SystemStatusItem(),
             onHintMode: onHintMode,
             onSearchMode: onSearchMode,
             onScrollMode: onScrollMode,
-            loginItemManager: loginItemManager
+            loginItemManager: loginItemManager,
+            hintModeSettings: hintModeSettings
         )
     }
 
@@ -77,13 +81,15 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         onHintMode: @escaping () -> Void,
         onSearchMode: @escaping () -> Void,
         onScrollMode: @escaping () -> Void,
-        loginItemManager: LoginItemManager? = nil
+        loginItemManager: LoginItemManager? = nil,
+        hintModeSettings: HintModeSettings
     ) {
         self.statusItem = statusItem
         self.onHintMode = onHintMode
         self.onSearchMode = onSearchMode
         self.onScrollMode = onScrollMode
         self.loginItemManager = loginItemManager
+        self.hintModeSettings = hintModeSettings
 
         super.init()
 
@@ -151,6 +157,16 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
         menu.addItem(.separator())
 
+        // ── Continuous Hint Mode ─────────────────
+        let continuousItem = NSMenuItem(
+            title: "Continuous Hint Mode",
+            action: #selector(toggleContinuousHintMode),
+            keyEquivalent: ""
+        )
+        continuousItem.target = self
+        continuousItem.tag = MenuItemTag.continuousHintMode
+        menu.addItem(continuousItem)
+
         // ── Launch at Login ───────────────────────
         let launchAtLoginItem = NSMenuItem(
             title: "Launch at Login",
@@ -180,6 +196,10 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     // MARK: - NSMenuDelegate
 
     func menuWillOpen(_ menu: NSMenu) {
+        if let item = menu.item(withTag: MenuItemTag.continuousHintMode) {
+            item.state = hintModeSettings.isContinuousMode ? .on : .off
+        }
+
         if let item = menu.item(withTag: MenuItemTag.launchAtLogin) {
             if let loginItemManager {
                 loginItemManager.syncWithSystem()
@@ -212,6 +232,10 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
     @objc private func toggleLaunchAtLogin() {
         loginItemManager?.toggle()
+    }
+
+    @objc private func toggleContinuousHintMode() {
+        hintModeSettings.toggle()
     }
 
     @objc private func quitApp() {

--- a/Tests/VimursorTests/HintModeControllerTests.swift
+++ b/Tests/VimursorTests/HintModeControllerTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+@testable import Vimursor
+
+@Suite
+struct HintModeControllerTests {
+
+    // MARK: - reactivationDelay 定数
+
+    private func makeSettings() -> HintModeSettings {
+        HintModeSettings(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+    }
+
+    @Test @MainActor func reactivationDelayIsThreeHundredMilliseconds() {
+        #expect(HintModeController.reactivationDelay == 0.3)
+    }
+
+    // MARK: - deactivate() が reactivationTask をクリアすること
+
+    @Test @MainActor func deactivateClearsReactivationTask() {
+        let controller = HintModeController(settings: makeSettings())
+        controller.deactivate()
+        #expect(controller.reactivationTask == nil)
+    }
+
+    // MARK: - HintModeSettings の注入
+
+    @Test @MainActor func controllerAcceptsSettings() {
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let settings = HintModeSettings(defaults: defaults)
+        let controller = HintModeController(settings: settings)
+        // settings が注入できることを確認（コンパイル通過 + deactivate が壊れない）
+        controller.deactivate()
+        #expect(controller.reactivationTask == nil)
+    }
+}

--- a/Tests/VimursorTests/HintModeSettingsTests.swift
+++ b/Tests/VimursorTests/HintModeSettingsTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import Vimursor
+
+@Suite
+struct HintModeSettingsTests {
+
+    // テスト用に分離した UserDefaults を使う
+    private func makeDefaults() -> UserDefaults {
+        UserDefaults(suiteName: UUID().uuidString)!
+    }
+
+    @Test @MainActor func defaultIsContinuousMode() {
+        let settings = HintModeSettings(defaults: makeDefaults())
+        #expect(settings.isContinuousMode == true)
+    }
+
+    @Test @MainActor func toggleSwitchesMode() {
+        let settings = HintModeSettings(defaults: makeDefaults())
+        settings.toggle()
+        #expect(settings.isContinuousMode == false)
+        settings.toggle()
+        #expect(settings.isContinuousMode == true)
+    }
+
+    @Test @MainActor func settingIsPersisted() {
+        let defaults = makeDefaults()
+        let settings1 = HintModeSettings(defaults: defaults)
+        settings1.toggle()  // true → false
+        let settings2 = HintModeSettings(defaults: defaults)
+        #expect(settings2.isContinuousMode == false)
+    }
+}

--- a/Tests/VimursorTests/StatusBarControllerTests.swift
+++ b/Tests/VimursorTests/StatusBarControllerTests.swift
@@ -16,6 +16,10 @@ final class MockStatusItem: StatusItemProvider {
 @Suite("StatusBarControllerTests")
 struct StatusBarControllerTests {
 
+    private func makeSettings() -> HintModeSettings {
+        HintModeSettings(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+    }
+
     @Test("onHintMode クロージャが呼ばれること")
     @MainActor
     func hintModeCallbackIsInvoked() {
@@ -27,7 +31,8 @@ struct StatusBarControllerTests {
             statusItem: MockStatusItem(),
             onHintMode: { hintCalled = true },
             onSearchMode: { searchCalled = true },
-            onScrollMode: { scrollCalled = true }
+            onScrollMode: { scrollCalled = true },
+            hintModeSettings: makeSettings()
         )
 
         controller.simulateHintMode()
@@ -47,7 +52,8 @@ struct StatusBarControllerTests {
             statusItem: MockStatusItem(),
             onHintMode: { hintCalled = true },
             onSearchMode: { searchCalled = true },
-            onScrollMode: { scrollCalled = true }
+            onScrollMode: { scrollCalled = true },
+            hintModeSettings: makeSettings()
         )
 
         controller.simulateSearchMode()
@@ -67,7 +73,8 @@ struct StatusBarControllerTests {
             statusItem: MockStatusItem(),
             onHintMode: { hintCalled = true },
             onSearchMode: { searchCalled = true },
-            onScrollMode: { scrollCalled = true }
+            onScrollMode: { scrollCalled = true },
+            hintModeSettings: makeSettings()
         )
 
         controller.simulateScrollMode()
@@ -84,11 +91,27 @@ struct StatusBarControllerTests {
             statusItem: mockItem,
             onHintMode: {},
             onSearchMode: {},
-            onScrollMode: {}
+            onScrollMode: {},
+            hintModeSettings: makeSettings()
         )
         // Hint Mode, Search Mode, Scroll Mode, separator, About, separator,
-        // Launch at Login, separator, Quit = 9 items
-        #expect(mockItem.menu?.items.count == 9)
+        // Continuous Hint Mode, Launch at Login, separator, Quit = 10 items
+        #expect(mockItem.menu?.items.count == 10)
+    }
+
+    @Test("メニューに Continuous Hint Mode 項目が含まれること")
+    @MainActor
+    func menuContainsContinuousHintModeItem() {
+        let mockItem = MockStatusItem()
+        _ = StatusBarController(
+            statusItem: mockItem,
+            onHintMode: {},
+            onSearchMode: {},
+            onScrollMode: {},
+            hintModeSettings: makeSettings()
+        )
+        let titles = mockItem.menu?.items.map(\.title) ?? []
+        #expect(titles.contains("Continuous Hint Mode"))
     }
 
     @Test("メニュータイトルが正しいこと")
@@ -99,7 +122,8 @@ struct StatusBarControllerTests {
             statusItem: mockItem,
             onHintMode: {},
             onSearchMode: {},
-            onScrollMode: {}
+            onScrollMode: {},
+            hintModeSettings: makeSettings()
         )
         let titles = mockItem.menu?.items.map(\.title) ?? []
         #expect(titles.contains("Hint Mode"))


### PR DESCRIPTION
## 概要

ヒントモードで要素クリック後に自動で再起動する「連続モード」を追加し、メニューバーから連続/単発を切り替えられるようにするPRです（設定は UserDefaults に永続化）。
PR #44 の Copilot レビュー指摘を修正した再PR。

## 変更内容

- HintModeController に `.restarting` 状態と自動再起動（300ms delay）を追加
- 連続/単発を `HintModeSettings`（UserDefaults）で切替可能に
- ステータスバーに "Continuous Hint Mode" トグルを追加
- AppDelegate から HintModeSettings を HintModeController / StatusBarController に注入
- clickDelay 中の ESC キャンセル対応（state guard）
- CancellationError 適切処理（`Task<Void, Never>`）
- reactivationTask 完了後の nil クリア
- weak ref 解放時の孤立 keyEventHandler 防止

## 関連 Issue

Closes #41
Closes #42
Epic: #25

## テスト

- [x] `swift build` が通ることを確認した
- [x] `swift test` が通ることを確認した（73テスト全通過）
- [ ] 手動動作確認済み

## チェックリスト

- [x] コミットメッセージが規則に従っている