### PR TITLE
fix: AccessibilityPermissionMonitor を Task.sleep ベースに変更（CI安定化）

### DIFF
--- a/Sources/Vimursor/AccessibilityPermission/AccessibilityPermissionMonitor.swift
+++ b/Sources/Vimursor/AccessibilityPermission/AccessibilityPermissionMonitor.swift
@@ -14,7 +14,7 @@ final class AccessibilityPermissionMonitor {
 
     private let checker: any AccessibilityPermissionChecker
     private let interval: TimeInterval
-    private var timer: Timer?
+    private var pollingTask: Task<Void, Never>?
     private var onGranted: (() -> Void)?
 
     // MARK: - Initialization
@@ -27,35 +27,34 @@ final class AccessibilityPermissionMonitor {
         self.interval = interval
     }
 
-    // NOTE: deinit では Timer の invalidate を行わない。
+    // NOTE: deinit では Task のキャンセルを行わない。
     // Swift 6 の deinit は nonisolated であり、@MainActor プロパティへの直接アクセスは不可。
     // MainActor.assumeIsolated はバックグラウンドスレッドからの解放時にクラッシュするリスクがある。
     // 呼び出し側が不要になったタイミングで stopPolling() を呼ぶこと。
 
     // MARK: - Public interface
 
-    /// ポーリングを開始する。権限が付与されたら `onGranted` を呼び出してタイマーを停止する。
-    /// すでにポーリング中の場合は先のタイマーを無効化してから再開する。
+    /// ポーリングを開始する。権限が付与されたら `onGranted` を呼び出してタスクを停止する。
+    /// すでにポーリング中の場合は先のタスクをキャンセルしてから再開する。
     /// - Parameter onGranted: 権限付与検出時に **メインスレッド** で呼ばれるクロージャ
     func startPolling(onGranted: @escaping () -> Void) {
         stopPolling()
         self.onGranted = onGranted
 
-        timer = Timer.scheduledTimer(
-            withTimeInterval: interval,
-            repeats: true
-        ) { [weak self] _ in
-            // Timer コールバックは @MainActor 外から来ることがあるため MainActor で実行
-            Task { @MainActor [weak self] in
-                self?.handleTimerFire()
+        pollingTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                self.handleTimerFire()
+                guard !Task.isCancelled else { return }
+                try? await Task.sleep(nanoseconds: UInt64(self.interval * 1_000_000_000))
             }
         }
     }
 
     /// ポーリングを停止する。
     func stopPolling() {
-        timer?.invalidate()
-        timer = nil
+        pollingTask?.cancel()
+        pollingTask = nil
         onGranted = nil
     }
 

--- a/Tests/VimursorTests/AccessibilityPermissionMonitorTests.swift
+++ b/Tests/VimursorTests/AccessibilityPermissionMonitorTests.swift
@@ -37,7 +37,7 @@ struct AccessibilityPermissionMonitorTests {
             called = true
         }
 
-        // Timer は RunLoop 経由なので少し待つ
+        // 最初のポーリングが終わるまで待つ
         try await Task.sleep(nanoseconds: 200_000_000) // 0.2s
         monitor.stopPolling()
 


### PR DESCRIPTION
## 概要

AccessibilityPermissionMonitor の Timer + RunLoop 依存を排除し、Task.sleep ベースのポーリングに変更。CI環境（GitHub Actions）でテストが安定して通るようにする。

## 変更内容

- `Timer.scheduledTimer` → `Task<Void, Never>` + `Task.sleep` ループに置き換え
- `@MainActor` 明示で冗長な `MainActor.run` ブリッジを除去
- `guard let self` で孤��� Task リーク防止
- check-first 順序で権限付与済み時の即座検出
- テストコメント更新（RunLoop 言及を削除）

## 関連 Issue

Closes #48

## テスト

- [x] `swift build` が通ることを確認した
- [x] `swift test` が通ることを確認した（73テスト全通過）
- [ ] 手動動作確認済み

## チェック���スト

- [x] コミットメッセージが規則に従っている