### PR TITLE
feat: 検索モードヒントラベル選択 (Epic 11)

### DIFF
--- a/Sources/Vimursor/HintMode/HintModeController.swift
+++ b/Sources/Vimursor/HintMode/HintModeController.swift
@@ -117,7 +117,7 @@ final class HintModeController {
         // 修飾キー付きは無視（Cmd+Tab等）
         guard flags.intersection([.maskCommand, .maskControl, .maskAlternate]).isEmpty else { return }
 
-        guard let char = keyCodeToChar(keyCode) else { return }
+        guard let char = KeyCodeMapping.charFromKeyCode(keyCode) else { return }
 
         let newInput = input + char
         let matches = hints.filter { $0.label.hasPrefix(newInput) }
@@ -188,15 +188,5 @@ final class HintModeController {
         }
     }
 
-    private func keyCodeToChar(_ keyCode: CGKeyCode) -> String? {
-        // ホームポジション文字のキーコードマッピング
-        let map: [CGKeyCode: String] = [
-            0: "a", 11: "b", 8: "c", 2: "d", 14: "e",
-            3: "f", 5: "g", 4: "h", 34: "i", 38: "j",
-            40: "k", 37: "l", 46: "m", 45: "n", 31: "o",
-            35: "p", 12: "q", 15: "r", 1: "s", 17: "t",
-            32: "u", 9: "v", 13: "w", 7: "x", 16: "y", 6: "z"
-        ]
-        return map[keyCode]
-    }
+
 }

--- a/Sources/Vimursor/HintMode/HintModeController.swift
+++ b/Sources/Vimursor/HintMode/HintModeController.swift
@@ -7,10 +7,6 @@ private enum HintModeState {
     case restarting // クリック後〜再起動待ち。ESC のみ受付
 }
 
-private enum HintKeyCode {
-    static let esc: CGKeyCode = 53
-}
-
 // CGEventTapスレッドからアクティブ状態だけを読めるよう分離
 // すべてのUI操作はメインスレッドで実行する
 @MainActor
@@ -102,14 +98,14 @@ final class HintModeController {
 
     private func handleKey(keyCode: CGKeyCode, flags: CGEventFlags) {
         if case .restarting = state {
-            if keyCode == HintKeyCode.esc { deactivate() }  // ESC のみ受付
+            if keyCode == KeyCodeMapping.escapeKeyCode { deactivate() }  // ESC のみ受付
             return  // 他のキーは消費して無視
         }
 
         guard case .active(let hints, let input) = state else { return }
 
         // ESC
-        if keyCode == HintKeyCode.esc {
+        if keyCode == KeyCodeMapping.escapeKeyCode {
             deactivate()
             return
         }
@@ -187,6 +183,4 @@ final class HintModeController {
             }
         }
     }
-
-
 }

--- a/Sources/Vimursor/SearchMode/SearchModeController.swift
+++ b/Sources/Vimursor/SearchMode/SearchModeController.swift
@@ -1,9 +1,25 @@
 import AppKit
 
+// MARK: - キーコード定数
+
+private enum SearchKeyCode {
+    /// ESC キー
+    static let escape: CGKeyCode = 53
+}
+
+// MARK: - 状態
+
 private enum SearchModeState {
     case inactive
     case fetching  // 要素取得中（二重起動防止）
-    case active(elements: [SearchElementInfo], query: String, matched: [SearchElementInfo])
+    case searching(elements: [SearchElementInfo], query: String, matched: [SearchElementInfo])
+    case selecting(
+        elements: [SearchElementInfo],
+        query: String,
+        matched: [SearchElementInfo],
+        labels: [String],
+        input: String
+    )
 }
 
 @MainActor
@@ -56,7 +72,7 @@ final class SearchModeController {
             state = .inactive  // 要素がなければ inactive に戻す
             return
         }
-        state = .active(elements: elements, query: "", matched: elements)
+        state = .searching(elements: elements, query: "", matched: elements)
 
         let view = SearchView(frame: overlayWindow.contentView?.bounds ?? .zero)
         view.autoresizingMask = [.width, .height]
@@ -85,15 +101,7 @@ final class SearchModeController {
         view.focusSearchField()
 
         // CGEventTap は ESC のみ処理（Enter は NSTextField デリゲートで処理）
-        hotkeyManager.keyEventHandler = { [weak self] keyCode, _, _ in
-            guard let self else { return false }
-            // ESC (53) のみ消費
-            guard keyCode == 53 else { return false }
-            Task { @MainActor [weak self] in
-                self?.deactivate()
-            }
-            return true
-        }
+        setSearchingKeyHandler()
     }
 
     func deactivate() {
@@ -115,26 +123,126 @@ final class SearchModeController {
         return elements.filter { $0.searchableText.contains(q) }
     }
 
-    /// Enter 確定時に先頭マッチをクリックする（NSTextField デリゲート経由で呼ばれる）
-    private func executeSearch() {
-        guard case .active(_, _, let matched) = state, let first = matched.first else { return }
-        let frame = first.frame
-        deactivate()
-        Task { @MainActor [weak self] in
-            do {
-                try await Task.sleep(for: .seconds(0.05))
-            } catch is CancellationError {
-                return
+    // MARK: - キーハンドラ設定
+
+    /// searching 状態用: ESC のみ処理するハンドラを設定する
+    private func setSearchingKeyHandler() {
+        hotkeyManager?.keyEventHandler = { [weak self] keyCode, _, _ in
+            guard let self else { return false }
+            guard keyCode == SearchKeyCode.escape else { return false }
+            Task { @MainActor [weak self] in
+                self?.deactivate()
             }
-            self?.elementFetcher.clickAt(frame: frame)
+            return true
         }
     }
 
+    /// selecting 状態用: 全キーを消費して handleSelectingKey に渡すハンドラを設定する
+    private func setSelectingKeyHandler() {
+        hotkeyManager?.keyEventHandler = { [weak self] keyCode, flags, char in
+            guard let self else { return false }
+            Task { @MainActor [weak self] in
+                self?.handleSelectingKey(keyCode: keyCode, flags: flags, char: char)
+            }
+            return true
+        }
+    }
+
+    // MARK: - executeSearch
+
+    /// Enter 確定時の処理（NSTextField デリゲート経由で呼ばれる）
+    private func executeSearch() {
+        guard case .searching(let elements, let query, let matched) = state else { return }
+
+        switch matched.count {
+        case 0:
+            // マッチなし: 何もしない
+            break
+        case 1:
+            // マッチ1件: 即クリック
+            let frame = matched[0].frame
+            deactivate()
+            Task { @MainActor [weak self] in
+                do {
+                    try await Task.sleep(for: .seconds(0.05))
+                } catch is CancellationError {
+                    return
+                }
+                self?.elementFetcher.clickAt(frame: frame)
+            }
+        default:
+            // マッチ2件以上: selecting 状態に遷移
+            let labels = LabelGenerator.generateLabels(count: matched.count)
+            state = .selecting(
+                elements: elements,
+                query: query,
+                matched: matched,
+                labels: labels,
+                input: ""
+            )
+            setSelectingKeyHandler()
+        }
+    }
+
+    // MARK: - handleSelectingKey
+
+    /// selecting 状態でのキーイベント処理
+    private func handleSelectingKey(keyCode: CGKeyCode, flags: CGEventFlags, char: String) {
+        guard case .selecting(let elements, let query, let matched, let labels, let input) = state else { return }
+
+        if keyCode == SearchKeyCode.escape {
+            // ESC → searching に戻る（クエリ維持）
+            state = .searching(elements: elements, query: query, matched: matched)
+            setSearchingKeyHandler()
+            return
+        }
+
+        // ラベル文字入力: KeyCodeMapping 経由でアルファベット文字を取得
+        guard let char = KeyCodeMapping.charFromKeyCode(keyCode) else { return }
+
+        let newInput = input + char
+        let filtered = zip(labels, matched).filter { label, _ in
+            label.hasPrefix(newInput)
+        }
+
+        if filtered.isEmpty {
+            // マッチなし → deactivate
+            deactivate()
+            return
+        }
+
+        // 完全一致チェック
+        if let exactMatch = filtered.first(where: { label, _ in label == newInput }) {
+            let frame = exactMatch.1.frame
+            deactivate()
+            Task { @MainActor [weak self] in
+                do {
+                    try await Task.sleep(for: .seconds(0.05))
+                } catch is CancellationError {
+                    return
+                }
+                self?.elementFetcher.clickAt(frame: frame)
+            }
+            return
+        }
+
+        // prefix マッチが残っている → input を更新
+        state = .selecting(
+            elements: elements,
+            query: query,
+            matched: matched,
+            labels: labels,
+            input: newInput
+        )
+    }
+
+    // MARK: - applyQuery
+
     /// NSTextField からのクエリ更新（IME 確定後の文字列を受け取る）
     private func applyQuery(_ query: String) {
-        guard case .active(let elements, _, _) = state else { return }
+        guard case .searching(let elements, _, _) = state else { return }
         let matched = SearchModeController.filter(elements: elements, query: query)
-        state = .active(elements: elements, query: query, matched: matched)
+        state = .searching(elements: elements, query: query, matched: matched)
         searchView?.update(query: query, matched: matched)
     }
 }

--- a/Sources/Vimursor/SearchMode/SearchModeController.swift
+++ b/Sources/Vimursor/SearchMode/SearchModeController.swift
@@ -239,6 +239,7 @@ final class SearchModeController {
 
     /// selecting 状態に入る時に SearchView を更新する
     private func enterSelectingState(matched: [SearchElementInfo], labels: [String], input: String) {
+        searchView?.unfocusSearchField()
         searchView?.updateForSelecting(matched: matched, labels: labels, input: input)
     }
 

--- a/Sources/Vimursor/SearchMode/SearchModeController.swift
+++ b/Sources/Vimursor/SearchMode/SearchModeController.swift
@@ -199,6 +199,9 @@ final class SearchModeController {
             return
         }
 
+        // 修飾キー付きは無視（Cmd+Tab 等の誤発火防止）
+        guard flags.intersection([.maskCommand, .maskControl, .maskAlternate]).isEmpty else { return }
+
         // ラベル文字入力: KeyCodeMapping 経由でアルファベット文字を取得
         guard let char = KeyCodeMapping.charFromKeyCode(keyCode) else { return }
 

--- a/Sources/Vimursor/SearchMode/SearchModeController.swift
+++ b/Sources/Vimursor/SearchMode/SearchModeController.swift
@@ -1,12 +1,5 @@
 import AppKit
 
-// MARK: - キーコード定数
-
-private enum SearchKeyCode {
-    /// ESC キー
-    static let escape: CGKeyCode = 53
-}
-
 // MARK: - 状態
 
 private enum SearchModeState {
@@ -129,7 +122,7 @@ final class SearchModeController {
     private func setSearchingKeyHandler() {
         hotkeyManager?.keyEventHandler = { [weak self] keyCode, _, _ in
             guard let self else { return false }
-            guard keyCode == SearchKeyCode.escape else { return false }
+            guard keyCode == KeyCodeMapping.escapeKeyCode else { return false }
             Task { @MainActor [weak self] in
                 self?.deactivate()
             }
@@ -139,10 +132,10 @@ final class SearchModeController {
 
     /// selecting 状態用: 全キーを消費して handleSelectingKey に渡すハンドラを設定する
     private func setSelectingKeyHandler() {
-        hotkeyManager?.keyEventHandler = { [weak self] keyCode, flags, char in
+        hotkeyManager?.keyEventHandler = { [weak self] keyCode, flags, _ in
             guard let self else { return false }
             Task { @MainActor [weak self] in
-                self?.handleSelectingKey(keyCode: keyCode, flags: flags, char: char)
+                self?.handleSelectingKey(keyCode: keyCode, flags: flags)
             }
             return true
         }
@@ -188,10 +181,10 @@ final class SearchModeController {
     // MARK: - handleSelectingKey
 
     /// selecting 状態でのキーイベント処理
-    private func handleSelectingKey(keyCode: CGKeyCode, flags: CGEventFlags, char: String) {
+    private func handleSelectingKey(keyCode: CGKeyCode, flags: CGEventFlags) {
         guard case .selecting(let elements, let query, let matched, let labels, let input) = state else { return }
 
-        if keyCode == SearchKeyCode.escape {
+        if keyCode == KeyCodeMapping.escapeKeyCode {
             // ESC → searching に戻る（クエリ維持）
             state = .searching(elements: elements, query: query, matched: matched)
             returnToSearchingState(query: query, matched: matched)

--- a/Sources/Vimursor/SearchMode/SearchModeController.swift
+++ b/Sources/Vimursor/SearchMode/SearchModeController.swift
@@ -180,6 +180,7 @@ final class SearchModeController {
                 labels: labels,
                 input: ""
             )
+            enterSelectingState(matched: matched, labels: labels, input: "")
             setSelectingKeyHandler()
         }
     }
@@ -193,6 +194,7 @@ final class SearchModeController {
         if keyCode == SearchKeyCode.escape {
             // ESC → searching に戻る（クエリ維持）
             state = .searching(elements: elements, query: query, matched: matched)
+            returnToSearchingState(query: query, matched: matched)
             setSearchingKeyHandler()
             return
         }
@@ -234,6 +236,20 @@ final class SearchModeController {
             labels: labels,
             input: newInput
         )
+        enterSelectingState(matched: matched, labels: labels, input: newInput)
+    }
+
+    // MARK: - SearchView 状態連携
+
+    /// selecting 状態に入る時に SearchView を更新する
+    private func enterSelectingState(matched: [SearchElementInfo], labels: [String], input: String) {
+        searchView?.updateForSelecting(matched: matched, labels: labels, input: input)
+        searchView?.unfocusSearchField()
+    }
+
+    /// searching 状態に戻る時に SearchView を更新する
+    private func returnToSearchingState(query: String, matched: [SearchElementInfo]) {
+        searchView?.returnToSearching(query: query, matched: matched)
     }
 
     // MARK: - applyQuery

--- a/Sources/Vimursor/SearchMode/SearchModeController.swift
+++ b/Sources/Vimursor/SearchMode/SearchModeController.swift
@@ -247,7 +247,6 @@ final class SearchModeController {
     /// selecting 状態に入る時に SearchView を更新する
     private func enterSelectingState(matched: [SearchElementInfo], labels: [String], input: String) {
         searchView?.updateForSelecting(matched: matched, labels: labels, input: input)
-        searchView?.unfocusSearchField()
     }
 
     /// searching 状態に戻る時に SearchView を更新する

--- a/Sources/Vimursor/SearchMode/SearchView.swift
+++ b/Sources/Vimursor/SearchMode/SearchView.swift
@@ -29,13 +29,44 @@ private enum SearchBarLayout {
     static let shadowColorAlpha: CGFloat = 0.3
 }
 
+// MARK: - ラベル描画定数
+private enum LabelStyle {
+    /// ラベルフォントサイズ（pt）
+    static let fontSize: CGFloat = 11
+    /// ラベルテキストパディング（px）
+    static let padding: CGFloat = 3
+    /// ラベル角丸半径（pt）
+    static let cornerRadius: CGFloat = 3
+    /// マッチラベル背景アルファ
+    static let matchBgAlpha: CGFloat = 0.95
+    /// 非マッチラベル背景アルファ
+    static let noMatchBgAlpha: CGFloat = 0.5
+    /// マッチラベル枠アルファ
+    static let matchBorderAlpha: CGFloat = 1.0
+    /// 非マッチラベル枠アルファ
+    static let noMatchBorderAlpha: CGFloat = 0.4
+}
+
+// MARK: - selecting 状態データ
+private struct SelectingData {
+    let matched: [SearchElementInfo]
+    let labels: [String]
+    let input: String
+}
+
 @MainActor
 final class SearchView: NSView {
     private var matchedElements: [SearchElementInfo] = []
     private var query: String = ""
 
+    /// selecting 状態のデータ（nil = searching 状態）
+    private var selectingData: SelectingData?
+
     // ブラー効果付きフローティングバーのコンテナ
     private let blurContainer: NSVisualEffectView
+
+    // selecting 中に blurContainer 上に重ねるオーバーレイ
+    private let selectingOverlay: NSView
 
     // NSTextField（検索バー部分）
     private let searchField: SearchTextField
@@ -50,10 +81,12 @@ final class SearchView: NSView {
 
     override init(frame: NSRect) {
         self.blurContainer = NSVisualEffectView()
+        self.selectingOverlay = NSView()
         self.searchField = SearchTextField()
         self.countLabel = SearchView.makeCountLabel()
         super.init(frame: frame)
         setupBlurContainer()
+        setupSelectingOverlay()
         setupTextField()
         setupCountLabel()
     }
@@ -81,6 +114,14 @@ final class SearchView: NSView {
 
         addSubview(blurContainer)
         updateBlurContainerFrame()
+    }
+
+    private func setupSelectingOverlay() {
+        selectingOverlay.wantsLayer = true
+        selectingOverlay.layer?.cornerRadius = SearchBarLayout.cornerRadius
+        selectingOverlay.layer?.backgroundColor = NSColor.systemBlue.withAlphaComponent(0.15).cgColor
+        selectingOverlay.isHidden = true
+        blurContainer.addSubview(selectingOverlay)
     }
 
     private func setupTextField() {
@@ -126,6 +167,8 @@ final class SearchView: NSView {
         // NSViewの原点は左下なので、下からのマージンをそのまま使う
         let y = SearchBarLayout.bottomMargin
         blurContainer.frame = CGRect(x: x, y: y, width: width, height: SearchBarLayout.height)
+        // selectingOverlay は blurContainer 全体を覆う
+        selectingOverlay.frame = CGRect(x: 0, y: 0, width: width, height: SearchBarLayout.height)
     }
 
     // MARK: - リサイズ対応
@@ -153,11 +196,37 @@ final class SearchView: NSView {
         window?.makeFirstResponder(searchField)
     }
 
+    func unfocusSearchField() {
+        window?.makeFirstResponder(nil)
+    }
+
+    /// selecting 状態に入る時・ラベル入力更新時に呼ぶ
+    func updateForSelecting(matched: [SearchElementInfo], labels: [String], input: String) {
+        selectingData = SelectingData(matched: matched, labels: labels, input: input)
+        searchField.isEditable = false
+        selectingOverlay.isHidden = false
+        needsDisplay = true
+    }
+
+    /// ESC で selecting → searching に戻る時に呼ぶ
+    func returnToSearching(query: String, matched: [SearchElementInfo]) {
+        selectingData = nil
+        searchField.isEditable = true
+        selectingOverlay.isHidden = true
+        self.query = query
+        self.matchedElements = matched
+        focusSearchField()
+        needsDisplay = true
+    }
+
     // MARK: - 描画
 
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
         drawHighlights()
+        if let data = selectingData {
+            drawLabels(data: data)
+        }
     }
 
     private func drawHighlights() {
@@ -170,6 +239,40 @@ final class SearchView: NSView {
             NSColor.systemGreen.withAlphaComponent(0.12).setFill()
             path.fill()
         }
+    }
+
+    private func drawLabels(data: SelectingData) {
+        for (label, element) in zip(data.labels, data.matched) {
+            let isMatch = data.input.isEmpty || label.hasPrefix(data.input)
+            drawLabel(label: label, frame: element.frame, isMatch: isMatch)
+        }
+    }
+
+    private func drawLabel(label: String, frame: CGRect, isMatch: Bool) {
+        let font = NSFont.systemFont(ofSize: LabelStyle.fontSize, weight: .semibold)
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: isMatch ? NSColor.black : NSColor.gray
+        ]
+
+        let size = (label as NSString).size(withAttributes: attrs)
+        let padding = LabelStyle.padding
+        let boxWidth = size.width + padding * 2
+        let boxHeight = size.height + padding * 2
+
+        let origin = CGPoint(x: frame.minX, y: frame.maxY)
+        let boxRect = CGRect(x: origin.x, y: origin.y, width: boxWidth, height: boxHeight)
+
+        let path = NSBezierPath(roundedRect: boxRect, xRadius: LabelStyle.cornerRadius, yRadius: LabelStyle.cornerRadius)
+        let bgColor: NSColor = isMatch ? .white : .lightGray
+        bgColor.withAlphaComponent(isMatch ? LabelStyle.matchBgAlpha : LabelStyle.noMatchBgAlpha).setFill()
+        path.fill()
+        NSColor.black.withAlphaComponent(isMatch ? LabelStyle.matchBorderAlpha : LabelStyle.noMatchBorderAlpha).setStroke()
+        path.lineWidth = 1.0
+        path.stroke()
+
+        let textOrigin = CGPoint(x: origin.x + padding, y: origin.y + padding)
+        (label as NSString).draw(at: textOrigin, withAttributes: attrs)
     }
 
     // MARK: - ファクトリ

--- a/Sources/Vimursor/SearchMode/SearchView.swift
+++ b/Sources/Vimursor/SearchMode/SearchView.swift
@@ -65,9 +65,6 @@ final class SearchView: NSView {
     // ブラー効果付きフローティングバーのコンテナ
     private let blurContainer: NSVisualEffectView
 
-    // selecting 中に blurContainer 上に重ねるオーバーレイ
-    private let selectingOverlay: NSView
-
     // NSTextField（検索バー部分）
     private let searchField: SearchTextField
 
@@ -81,12 +78,10 @@ final class SearchView: NSView {
 
     override init(frame: NSRect) {
         self.blurContainer = NSVisualEffectView()
-        self.selectingOverlay = NSView()
         self.searchField = SearchTextField()
         self.countLabel = SearchView.makeCountLabel()
         super.init(frame: frame)
         setupBlurContainer()
-        setupSelectingOverlay()
         setupTextField()
         setupCountLabel()
     }
@@ -114,14 +109,6 @@ final class SearchView: NSView {
 
         addSubview(blurContainer)
         updateBlurContainerFrame()
-    }
-
-    private func setupSelectingOverlay() {
-        selectingOverlay.wantsLayer = true
-        selectingOverlay.layer?.cornerRadius = SearchBarLayout.cornerRadius
-        selectingOverlay.layer?.backgroundColor = NSColor.systemBlue.withAlphaComponent(0.15).cgColor
-        selectingOverlay.isHidden = true
-        blurContainer.addSubview(selectingOverlay)
     }
 
     private func setupTextField() {
@@ -167,8 +154,6 @@ final class SearchView: NSView {
         // NSViewの原点は左下なので、下からのマージンをそのまま使う
         let y = SearchBarLayout.bottomMargin
         blurContainer.frame = CGRect(x: x, y: y, width: width, height: SearchBarLayout.height)
-        // selectingOverlay は blurContainer 全体を覆う
-        selectingOverlay.frame = CGRect(x: 0, y: 0, width: width, height: SearchBarLayout.height)
     }
 
     // MARK: - リサイズ対応
@@ -194,10 +179,6 @@ final class SearchView: NSView {
 
     func focusSearchField() {
         window?.makeFirstResponder(searchField)
-    }
-
-    func unfocusSearchField() {
-        window?.makeFirstResponder(nil)
     }
 
     /// selecting 状態に入る時・ラベル入力更新時に呼ぶ

--- a/Sources/Vimursor/SearchMode/SearchView.swift
+++ b/Sources/Vimursor/SearchMode/SearchView.swift
@@ -203,20 +203,16 @@ final class SearchView: NSView {
     /// selecting 状態に入る時・ラベル入力更新時に呼ぶ
     func updateForSelecting(matched: [SearchElementInfo], labels: [String], input: String) {
         selectingData = SelectingData(matched: matched, labels: labels, input: input)
-        searchField.isEditable = false
-        selectingOverlay.isHidden = false
-        needsDisplay = true
+        display()
     }
 
     /// ESC で selecting → searching に戻る時に呼ぶ
     func returnToSearching(query: String, matched: [SearchElementInfo]) {
         selectingData = nil
-        searchField.isEditable = true
-        selectingOverlay.isHidden = true
         self.query = query
         self.matchedElements = matched
         focusSearchField()
-        needsDisplay = true
+        display()
     }
 
     // MARK: - 描画

--- a/Sources/Vimursor/SearchMode/SearchView.swift
+++ b/Sources/Vimursor/SearchMode/SearchView.swift
@@ -71,6 +71,9 @@ final class SearchView: NSView {
     // マッチ件数表示ラベル
     private let countLabel: NSTextField
 
+    // selecting 状態を視覚的に示すオーバーレイ（blurContainer 上に重ねる）
+    private let selectingOverlay: NSView
+
     // コントローラからセットされるコールバック
     var onQueryChanged: QueryChangedHandler?
     // Enter 確定時のコールバック（IME 変換確定との区別は NSTextField デリゲートが担う）
@@ -80,10 +83,12 @@ final class SearchView: NSView {
         self.blurContainer = NSVisualEffectView()
         self.searchField = SearchTextField()
         self.countLabel = SearchView.makeCountLabel()
+        self.selectingOverlay = NSView()
         super.init(frame: frame)
         setupBlurContainer()
         setupTextField()
         setupCountLabel()
+        setupSelectingOverlay()
     }
 
     required init?(coder: NSCoder) { fatalError() }
@@ -140,6 +145,19 @@ final class SearchView: NSView {
         blurContainer.addSubview(countLabel)
     }
 
+    private func setupSelectingOverlay() {
+        // blurContainer 全体を覆うオーバーレイ（selecting 状態時に表示）
+        selectingOverlay.frame = CGRect(origin: .zero, size: CGSize(width: 0, height: SearchBarLayout.height))
+        selectingOverlay.autoresizingMask = [.width, .height]
+        selectingOverlay.wantsLayer = true
+        selectingOverlay.layer?.backgroundColor = NSColor.systemBlue.withAlphaComponent(0.15).cgColor
+        selectingOverlay.layer?.cornerRadius = SearchBarLayout.cornerRadius
+        selectingOverlay.isHidden = true
+        // ユーザー操作を透過させる（サブビューのイベントに影響しない）
+        selectingOverlay.frame = blurContainer.bounds
+        blurContainer.addSubview(selectingOverlay)
+    }
+
     // MARK: - フローティングバーの幅（現在のboundsから算出）
 
     private var barWidth: CGFloat {
@@ -181,10 +199,17 @@ final class SearchView: NSView {
         window?.makeFirstResponder(searchField)
     }
 
+    func unfocusSearchField() {
+        window?.makeFirstResponder(nil)
+    }
+
     /// selecting 状態に入る時・ラベル入力更新時に呼ぶ
     func updateForSelecting(matched: [SearchElementInfo], labels: [String], input: String) {
         selectingData = SelectingData(matched: matched, labels: labels, input: input)
-        display()
+        searchField.isEditable = false
+        selectingOverlay.isHidden = false
+        unfocusSearchField()
+        needsDisplay = true
     }
 
     /// ESC で selecting → searching に戻る時に呼ぶ
@@ -192,8 +217,10 @@ final class SearchView: NSView {
         selectingData = nil
         self.query = query
         self.matchedElements = matched
+        searchField.isEditable = true
+        selectingOverlay.isHidden = true
         focusSearchField()
-        display()
+        needsDisplay = true
     }
 
     // MARK: - 描画
@@ -207,7 +234,14 @@ final class SearchView: NSView {
     }
 
     private func drawHighlights() {
-        for info in matchedElements {
+        // selecting 状態では selectingData.matched からハイライトを描画する
+        let elements: [SearchElementInfo]
+        if let data = selectingData {
+            elements = data.matched
+        } else {
+            elements = matchedElements
+        }
+        for info in elements {
             let path = NSBezierPath(roundedRect: info.frame.insetBy(dx: -2, dy: -2), xRadius: 4, yRadius: 4)
             NSColor.systemGreen.withAlphaComponent(0.85).setStroke()
             path.lineWidth = 2.5

--- a/Sources/Vimursor/Shared/KeyCodeMapping.swift
+++ b/Sources/Vimursor/Shared/KeyCodeMapping.swift
@@ -1,0 +1,22 @@
+import CoreGraphics
+
+/// キーコード → アルファベット文字の共通マッピングユーティリティ
+/// HintModeController / SearchModeController から共有して使用する
+enum KeyCodeMapping {
+
+    /// キーコードと文字の全マッピング（US キーボードレイアウト準拠）
+    static let allMappings: [CGKeyCode: String] = [
+        0: "a", 11: "b", 8: "c", 2: "d", 14: "e",
+        3: "f", 5: "g", 4: "h", 34: "i", 38: "j",
+        40: "k", 37: "l", 46: "m", 45: "n", 31: "o",
+        35: "p", 12: "q", 15: "r", 1: "s", 17: "t",
+        32: "u", 9: "v", 13: "w", 7: "x", 16: "y", 6: "z"
+    ]
+
+    /// 指定キーコードに対応するアルファベット文字を返す
+    /// - Parameter keyCode: CGEventTap から受け取るキーコード
+    /// - Returns: 対応する文字（英小文字1文字）。マッピングに存在しない場合は nil
+    static func charFromKeyCode(_ keyCode: CGKeyCode) -> String? {
+        allMappings[keyCode]
+    }
+}

--- a/Sources/Vimursor/Shared/KeyCodeMapping.swift
+++ b/Sources/Vimursor/Shared/KeyCodeMapping.swift
@@ -4,6 +4,9 @@ import CoreGraphics
 /// HintModeController / SearchModeController から共有して使用する
 enum KeyCodeMapping {
 
+    /// ESC キーのキーコード
+    static let escapeKeyCode: CGKeyCode = 53
+
     /// キーコードと文字の全マッピング（US キーボードレイアウト準拠）
     static let allMappings: [CGKeyCode: String] = [
         0: "a", 11: "b", 8: "c", 2: "d", 14: "e",

--- a/Tests/VimursorTests/KeyCodeMappingTests.swift
+++ b/Tests/VimursorTests/KeyCodeMappingTests.swift
@@ -1,0 +1,116 @@
+import Testing
+@testable import Vimursor
+
+@Suite("KeyCodeMapping Tests")
+struct KeyCodeMappingTests {
+
+    // MARK: - 既知キーコードのマッピング
+
+    @Test("keyCode 0 returns 'a'")
+    func keyCode0ReturnsA() {
+        #expect(KeyCodeMapping.charFromKeyCode(0) == "a")
+    }
+
+    @Test("keyCode 11 returns 'b'")
+    func keyCode11ReturnsB() {
+        #expect(KeyCodeMapping.charFromKeyCode(11) == "b")
+    }
+
+    @Test("keyCode 8 returns 'c'")
+    func keyCode8ReturnsC() {
+        #expect(KeyCodeMapping.charFromKeyCode(8) == "c")
+    }
+
+    @Test("keyCode 2 returns 'd'")
+    func keyCode2ReturnsD() {
+        #expect(KeyCodeMapping.charFromKeyCode(2) == "d")
+    }
+
+    @Test("keyCode 14 returns 'e'")
+    func keyCode14ReturnsE() {
+        #expect(KeyCodeMapping.charFromKeyCode(14) == "e")
+    }
+
+    @Test("keyCode 3 returns 'f'")
+    func keyCode3ReturnsF() {
+        #expect(KeyCodeMapping.charFromKeyCode(3) == "f")
+    }
+
+    @Test("keyCode 38 returns 'j'")
+    func keyCode38ReturnsJ() {
+        #expect(KeyCodeMapping.charFromKeyCode(38) == "j")
+    }
+
+    @Test("keyCode 40 returns 'k'")
+    func keyCode40ReturnsK() {
+        #expect(KeyCodeMapping.charFromKeyCode(40) == "k")
+    }
+
+    @Test("keyCode 37 returns 'l'")
+    func keyCode37ReturnsL() {
+        #expect(KeyCodeMapping.charFromKeyCode(37) == "l")
+    }
+
+    @Test("keyCode 15 returns 'r'")
+    func keyCode15ReturnsR() {
+        #expect(KeyCodeMapping.charFromKeyCode(15) == "r")
+    }
+
+    // MARK: - 未知キーコードは nil を返す
+
+    @Test("unknown keyCode returns nil")
+    func unknownKeyCodeReturnsNil() {
+        #expect(KeyCodeMapping.charFromKeyCode(999) == nil)
+    }
+
+    @Test("keyCode 53 (ESC) returns nil")
+    func escKeyCodeReturnsNil() {
+        #expect(KeyCodeMapping.charFromKeyCode(53) == nil)
+    }
+
+    // MARK: - ラベルで使用するキーが全てマッピングされている
+
+    @Test("all label keys are mapped correctly")
+    func allLabelKeysAreMapped() {
+        // LabelGenerator.swift のデフォルトラベル文字
+        let labelKeys: [(UInt16, String)] = [
+            (3, "f"), (38, "j"), (15, "r"), (34, "i"), (14, "e"),
+            (31, "o"), (2, "d"), (40, "k"), (1, "s"), (37, "l"),
+            (0, "a"), (35, "p"), (45, "n"), (9, "v"), (46, "m"), (8, "c")
+        ]
+
+        for (keyCode, expectedChar) in labelKeys {
+            #expect(
+                KeyCodeMapping.charFromKeyCode(keyCode) == expectedChar,
+                "keyCode \(keyCode) should map to '\(expectedChar)'"
+            )
+        }
+    }
+
+    // MARK: - アルファベット全26文字が網羅されている
+
+    @Test("all 26 alphabet characters are mapped")
+    func allAlphabetCharactersMapped() {
+        let allAlphabetChars: Set<String> = [
+            "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
+            "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"
+        ]
+
+        let mappedChars = Set(KeyCodeMapping.allMappings.values)
+        #expect(mappedChars == allAlphabetChars)
+    }
+
+    // MARK: - マッピングの一意性
+
+    @Test("each keyCode maps to a unique character")
+    func eachKeyCodeMapsToUniqueChar() {
+        let values = Array(KeyCodeMapping.allMappings.values)
+        let uniqueValues = Set(values)
+        #expect(values.count == uniqueValues.count)
+    }
+
+    @Test("total mapping count is 26")
+    func mappingCountIs26() {
+        #expect(KeyCodeMapping.allMappings.count == 26)
+    }
+}

--- a/Tests/VimursorTests/KeyCodeMappingTests.swift
+++ b/Tests/VimursorTests/KeyCodeMappingTests.swift
@@ -4,58 +4,6 @@ import Testing
 @Suite("KeyCodeMapping Tests")
 struct KeyCodeMappingTests {
 
-    // MARK: - 既知キーコードのマッピング
-
-    @Test("keyCode 0 returns 'a'")
-    func keyCode0ReturnsA() {
-        #expect(KeyCodeMapping.charFromKeyCode(0) == "a")
-    }
-
-    @Test("keyCode 11 returns 'b'")
-    func keyCode11ReturnsB() {
-        #expect(KeyCodeMapping.charFromKeyCode(11) == "b")
-    }
-
-    @Test("keyCode 8 returns 'c'")
-    func keyCode8ReturnsC() {
-        #expect(KeyCodeMapping.charFromKeyCode(8) == "c")
-    }
-
-    @Test("keyCode 2 returns 'd'")
-    func keyCode2ReturnsD() {
-        #expect(KeyCodeMapping.charFromKeyCode(2) == "d")
-    }
-
-    @Test("keyCode 14 returns 'e'")
-    func keyCode14ReturnsE() {
-        #expect(KeyCodeMapping.charFromKeyCode(14) == "e")
-    }
-
-    @Test("keyCode 3 returns 'f'")
-    func keyCode3ReturnsF() {
-        #expect(KeyCodeMapping.charFromKeyCode(3) == "f")
-    }
-
-    @Test("keyCode 38 returns 'j'")
-    func keyCode38ReturnsJ() {
-        #expect(KeyCodeMapping.charFromKeyCode(38) == "j")
-    }
-
-    @Test("keyCode 40 returns 'k'")
-    func keyCode40ReturnsK() {
-        #expect(KeyCodeMapping.charFromKeyCode(40) == "k")
-    }
-
-    @Test("keyCode 37 returns 'l'")
-    func keyCode37ReturnsL() {
-        #expect(KeyCodeMapping.charFromKeyCode(37) == "l")
-    }
-
-    @Test("keyCode 15 returns 'r'")
-    func keyCode15ReturnsR() {
-        #expect(KeyCodeMapping.charFromKeyCode(15) == "r")
-    }
-
     // MARK: - 未知キーコードは nil を返す
 
     @Test("unknown keyCode returns nil")

--- a/Tests/VimursorTests/SearchModeControllerTests.swift
+++ b/Tests/VimursorTests/SearchModeControllerTests.swift
@@ -189,9 +189,10 @@ struct SearchModeControllerTests {
         searchView.onEnterPressed?()
         try await Task.sleep(for: .milliseconds(100))
 
-        // Cmd+F（修飾キー付き）を送信 — 無視されること
-        // keyCode 3 = 'f'（ラベル先頭文字）, flags = .maskCommand
-        _ = hotkey.simulateKey(3, flags: .maskCommand, char: "f")
+        // Cmd+<先頭ラベル文字>（修飾キー付き）を送信 — 無視されること
+        let firstLabel = LabelGenerator.generateLabels(count: 2)[0]
+        let firstKeyCode = KeyCodeMapping.allMappings.first(where: { $0.value == firstLabel })?.key ?? 3
+        _ = hotkey.simulateKey(firstKeyCode, flags: .maskCommand)
         try await Task.sleep(for: .milliseconds(100))
 
         // クリックなし・deactivate なし（ハンドラが維持されている）
@@ -256,7 +257,7 @@ struct SearchModeControllerTests {
 
     @Test("selecting 中の完全一致でクリックが実行される")
     func selectingExactMatchTriggerClick() async throws {
-        // 要素が2つ: ラベルは "a", "b" となる（singleChar）
+        // 要素が2つ: ラベルは LabelGenerator が生成した先頭ラベルを使う
         let elements = [
             makeSearchInfo(title: "Save"),
             makeSearchInfo(title: "Close")
@@ -273,8 +274,14 @@ struct SearchModeControllerTests {
         searchView.onEnterPressed?()
         try await Task.sleep(for: .milliseconds(100))
 
-        // keyCode 3 = 'f' を入力 → ラベル "f" に完全一致 → クリック
-        _ = hotkey.simulateKey(3, flags: [], char: "f")
+        // 先頭ラベルと対応する keyCode を動的に解決する
+        let firstLabel = LabelGenerator.generateLabels(count: 2)[0]
+        guard let keyCode = KeyCodeMapping.allMappings.first(where: { $0.value == firstLabel })?.key else {
+            return  // マッピングが存在しない場合はスキップ
+        }
+
+        // 先頭ラベルに完全一致するキーを送信 → クリック
+        _ = hotkey.simulateKey(keyCode)
         try await Task.sleep(for: .milliseconds(300))
 
         // deactivate されてクリックが 1 回発生

--- a/Tests/VimursorTests/SearchModeControllerTests.swift
+++ b/Tests/VimursorTests/SearchModeControllerTests.swift
@@ -282,6 +282,152 @@ struct SearchModeControllerTests {
         #expect(hotkey.keyEventHandler == nil)
     }
 
+    // MARK: - 追加統合テスト・回帰テスト
+
+    @Test("マッチ0件でEnter → searching のまま変化なし")
+    func executeSearchWithZeroMatchesDoesNothing() async throws {
+        let element = makeSearchInfo(title: "Save")
+        let (controller, overlay, hotkey, fetcher) = makeSUT(elements: [element])
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(100))
+
+        guard let searchView = overlay.contentView?.subviews.first(where: { $0 is SearchView }) as? SearchView else {
+            return  // UI 環境なし（CI等）では SearchView が生成されない
+        }
+
+        // クエリをマッチなし状態にしてから Enter を発火
+        // onQueryChanged を呼んで matched を 0 件に絞る
+        searchView.onQueryChanged?("zzzzz_no_match")
+        try await Task.sleep(for: .milliseconds(50))
+
+        searchView.onEnterPressed?()
+        try await Task.sleep(for: .milliseconds(200))
+
+        // クリックされない・deactivate されない（ハンドラが維持される）
+        #expect(fetcher.clickAtCallCount == 0)
+        #expect(hotkey.keyEventHandler != nil)
+    }
+
+    @Test("searching 中の ESC → deactivate")
+    func searchingEscDeactivates() async throws {
+        let element = makeSearchInfo(title: "Save")
+        let (controller, overlay, hotkey, _) = makeSUT(elements: [element])
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(100))
+
+        guard overlay.contentView?.subviews.first(where: { $0 is SearchView }) != nil else {
+            return  // UI 環境なし（CI等）では SearchView が生成されない
+        }
+
+        // searching 状態で ESC を送信（keyCode 53）
+        let consumed = hotkey.simulateKey(53)
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(consumed == true)
+        // deactivate により keyEventHandler が nil になること
+        #expect(hotkey.keyEventHandler == nil)
+        // overlay が hide されること
+        #expect(overlay.hideCallCount >= 1)
+    }
+
+    @Test("selecting 状態から deactivate するとクリーンアップされる")
+    func deactivateFromSelectingStateCleansUp() async throws {
+        let elements = [
+            makeSearchInfo(title: "Save"),
+            makeSearchInfo(title: "Save As")
+        ]
+        let (controller, overlay, hotkey, fetcher) = makeSUT(elements: elements)
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(100))
+
+        guard let searchView = overlay.contentView?.subviews.first(where: { $0 is SearchView }) as? SearchView else {
+            return  // UI 環境なし（CI等）では SearchView が生成されない
+        }
+
+        // selecting 状態に遷移
+        searchView.onEnterPressed?()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // selecting 状態から直接 deactivate
+        controller.deactivate()
+        try await Task.sleep(for: .milliseconds(50))
+
+        // クリーンアップが正しく行われること
+        #expect(hotkey.keyEventHandler == nil)
+        #expect(overlay.hideCallCount >= 1)
+        #expect(fetcher.clickAtCallCount == 0)
+    }
+
+    @Test("selecting → searching → Enter → 再び selecting に遷移できる（往復テスト）")
+    func selectingToSearchingAndBackToSelectingWorks() async throws {
+        let elements = [
+            makeSearchInfo(title: "Save"),
+            makeSearchInfo(title: "Save As")
+        ]
+        let (controller, overlay, hotkey, fetcher) = makeSUT(elements: elements)
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(100))
+
+        guard let searchView = overlay.contentView?.subviews.first(where: { $0 is SearchView }) as? SearchView else {
+            return  // UI 環境なし（CI等）では SearchView が生成されない
+        }
+
+        // 1回目: Enter で selecting に遷移
+        searchView.onEnterPressed?()
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(hotkey.keyEventHandler != nil)  // selecting ハンドラが設定されている
+
+        // ESC で searching に戻る
+        hotkey.simulateKey(53)
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(hotkey.keyEventHandler != nil)  // searching ハンドラが設定されている
+
+        // 2回目: Enter で再び selecting に遷移できること
+        searchView.onEnterPressed?()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // クリックなし（selecting 状態）かつハンドラが設定されていること
+        #expect(fetcher.clickAtCallCount == 0)
+        #expect(hotkey.keyEventHandler != nil)
+    }
+
+    @Test("selecting 中 ESC で searching に戻ったときクエリが維持される（詳細検証）")
+    func selectingEscMaintainsQueryInSearching() async throws {
+        let elements = [
+            makeSearchInfo(title: "Save"),
+            makeSearchInfo(title: "Save As")
+        ]
+        let (controller, overlay, hotkey, fetcher) = makeSUT(elements: elements)
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(100))
+
+        guard let searchView = overlay.contentView?.subviews.first(where: { $0 is SearchView }) as? SearchView else {
+            return  // UI 環境なし（CI等）では SearchView が生成されない
+        }
+
+        // クエリを "save" に設定してから Enter → selecting
+        searchView.onQueryChanged?("save")
+        try await Task.sleep(for: .milliseconds(50))
+        searchView.onEnterPressed?()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // ESC で searching に戻る
+        hotkey.simulateKey(53)
+        try await Task.sleep(for: .milliseconds(100))
+
+        // searching 状態に戻っているのでクリックなし・ハンドラ維持
+        #expect(fetcher.clickAtCallCount == 0)
+        #expect(hotkey.keyEventHandler != nil)
+
+        // searching に戻った後、Enter を再度押すと再び selecting に遷移（クエリが有効）
+        searchView.onEnterPressed?()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // 2件マッチ（"Save", "Save As"）のため selecting 状態に遷移
+        #expect(fetcher.clickAtCallCount == 0)
+        #expect(hotkey.keyEventHandler != nil)
+    }
+
     @Test func filterByTitle() {
         let elements = [makeInfo(title: "Save"), makeInfo(title: "Cancel")]
         let result = SearchModeController.filter(elements: elements, query: "save")

--- a/Tests/VimursorTests/SearchModeControllerTests.swift
+++ b/Tests/VimursorTests/SearchModeControllerTests.swift
@@ -169,6 +169,119 @@ struct SearchModeControllerTests {
         )
     }
 
+    // MARK: - selecting キー入力処理テスト
+
+    @Test("selecting 中の修飾キー付きキーは無視される")
+    func selectingIgnoresModifierKeys() async throws {
+        let elements = [
+            makeSearchInfo(title: "Save"),
+            makeSearchInfo(title: "Save As")
+        ]
+        let (controller, overlay, hotkey, fetcher) = makeSUT(elements: elements)
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(100))
+
+        guard let searchView = overlay.contentView?.subviews.first(where: { $0 is SearchView }) as? SearchView else {
+            return
+        }
+
+        // Enter で selecting に遷移
+        searchView.onEnterPressed?()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Cmd+F（修飾キー付き）を送信 — 無視されること
+        // keyCode 3 = 'f'（ラベル先頭文字）, flags = .maskCommand
+        _ = hotkey.simulateKey(3, flags: .maskCommand, char: "f")
+        try await Task.sleep(for: .milliseconds(100))
+
+        // クリックなし・deactivate なし（ハンドラが維持されている）
+        #expect(fetcher.clickAtCallCount == 0)
+        #expect(hotkey.keyEventHandler != nil)
+    }
+
+    @Test("selecting 中にマッチなし → deactivate")
+    func selectingNoMatchDeactivates() async throws {
+        let elements = [
+            makeSearchInfo(title: "Save"),
+            makeSearchInfo(title: "Save As")
+        ]
+        let (controller, overlay, hotkey, fetcher) = makeSUT(elements: elements)
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(100))
+
+        guard let searchView = overlay.contentView?.subviews.first(where: { $0 is SearchView }) as? SearchView else {
+            return
+        }
+
+        // Enter で selecting に遷移（ラベルは "a", "b" 等が生成される）
+        searchView.onEnterPressed?()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // ラベルに存在しない文字を入力（KeyCodeMapping で 'z' は存在しない場合もあるため 'z' ではなく 'q' + 'z' の連続で確実にマッチなしを作る）
+        // KeyCode 12 = 'q'、まず 'q' を入力してから 'q' を再度入力（"qq" は "a", "b" にマッチしない）
+        _ = hotkey.simulateKey(12, flags: [], char: "q")  // 'q'
+        try await Task.sleep(for: .milliseconds(100))
+        _ = hotkey.simulateKey(12, flags: [], char: "q")  // 'qq' はマッチなし
+        try await Task.sleep(for: .milliseconds(100))
+
+        // クリックなし・deactivate されてハンドラが nil
+        #expect(fetcher.clickAtCallCount == 0)
+        #expect(hotkey.keyEventHandler == nil)
+    }
+
+    @Test("selecting 中の prefix マッチで状態が更新される")
+    func selectingPrefixMatchUpdatesState() async throws {
+        let elements = [
+            makeSearchInfo(title: "Save"),
+            makeSearchInfo(title: "Save As"),
+            makeSearchInfo(title: "Close")
+        ]
+        let (controller, overlay, hotkey, fetcher) = makeSUT(elements: elements)
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(100))
+
+        guard let searchView = overlay.contentView?.subviews.first(where: { $0 is SearchView }) as? SearchView else {
+            return
+        }
+
+        // Enter で selecting に遷移（ラベルは 2 文字: aa, ab, ba 等）
+        searchView.onEnterPressed?()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // クリックまたはマッチなしになるまでハンドラが維持されていること
+        #expect(hotkey.keyEventHandler != nil)
+        // クリックはまだ発生していない
+        #expect(fetcher.clickAtCallCount == 0)
+    }
+
+    @Test("selecting 中の完全一致でクリックが実行される")
+    func selectingExactMatchTriggerClick() async throws {
+        // 要素が2つ: ラベルは "a", "b" となる（singleChar）
+        let elements = [
+            makeSearchInfo(title: "Save"),
+            makeSearchInfo(title: "Close")
+        ]
+        let (controller, overlay, hotkey, fetcher) = makeSUT(elements: elements)
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(100))
+
+        guard let searchView = overlay.contentView?.subviews.first(where: { $0 is SearchView }) as? SearchView else {
+            return
+        }
+
+        // Enter で selecting に遷移
+        searchView.onEnterPressed?()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // keyCode 3 = 'f' を入力 → ラベル "f" に完全一致 → クリック
+        _ = hotkey.simulateKey(3, flags: [], char: "f")
+        try await Task.sleep(for: .milliseconds(300))
+
+        // deactivate されてクリックが 1 回発生
+        #expect(fetcher.clickAtCallCount == 1)
+        #expect(hotkey.keyEventHandler == nil)
+    }
+
     @Test func filterByTitle() {
         let elements = [makeInfo(title: "Save"), makeInfo(title: "Cancel")]
         let result = SearchModeController.filter(elements: elements, query: "save")

--- a/Tests/VimursorTests/SearchModeControllerTests.swift
+++ b/Tests/VimursorTests/SearchModeControllerTests.swift
@@ -77,6 +77,82 @@ struct SearchModeControllerTests {
         #expect(overlay.hideCallCount >= 1)
     }
 
+    // MARK: - マッチ件数による分岐テスト
+
+    @Test("マッチ1件でEnter → 即クリック（回帰テスト）")
+    func executeSearchWithSingleMatchClicksImmediately() async throws {
+        let element = makeSearchInfo(title: "Save")
+        let (controller, overlay, hotkey, fetcher) = makeSUT(elements: [element])
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(100))
+
+        // frontmostApplication が nil の場合は searchView が設定されないため、テストをスキップ
+        guard let searchView = overlay.contentView?.subviews.first(where: { $0 is SearchView }) as? SearchView else {
+            return  // UI 環境なし（CI等）では SearchView が生成されない
+        }
+
+        // SearchView の onEnterPressed を直接発火
+        searchView.onEnterPressed?()
+        try await Task.sleep(for: .milliseconds(300))
+
+        // deactivate が呼ばれ、clickAt が 1 回実行されること
+        #expect(fetcher.clickAtCallCount == 1)
+        #expect(hotkey.keyEventHandler == nil)
+    }
+
+    @Test("マッチ2件以上でEnter → selecting 状態に遷移")
+    func executeSearchWithMultipleMatchesTransitionsToSelecting() async throws {
+        let elements = [
+            makeSearchInfo(title: "Save"),
+            makeSearchInfo(title: "Save As")
+        ]
+        let (controller, overlay, hotkey, fetcher) = makeSUT(elements: elements)
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(100))
+
+        guard let searchView = overlay.contentView?.subviews.first(where: { $0 is SearchView }) as? SearchView else {
+            return  // UI 環境なし（CI等）では SearchView が生成されない
+        }
+
+        // SearchView の onEnterPressed を直接発火
+        searchView.onEnterPressed?()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // selecting 状態ではクリックされない
+        #expect(fetcher.clickAtCallCount == 0)
+        // keyEventHandler が selecting モード（全キー消費）に変わること
+        #expect(hotkey.keyEventHandler != nil)
+    }
+
+    @Test("selecting 中の ESC → searching に戻る（クエリ維持）")
+    func selectingEscReturnsToSearching() async throws {
+        let elements = [
+            makeSearchInfo(title: "Save"),
+            makeSearchInfo(title: "Save As")
+        ]
+        let (controller, overlay, hotkey, fetcher) = makeSUT(elements: elements)
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(100))
+
+        guard let searchView = overlay.contentView?.subviews.first(where: { $0 is SearchView }) as? SearchView else {
+            return  // UI 環境なし（CI等）では SearchView が生成されない
+        }
+
+        // Enter で selecting に遷移
+        searchView.onEnterPressed?()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // ESC で searching に戻る（ESC keyCode = 53）
+        let consumed = hotkey.simulateKey(53)
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(consumed == true)
+        // searching に戻っているのでクリックなし
+        #expect(fetcher.clickAtCallCount == 0)
+        // searching 中は ESC のみ処理するハンドラが設定されていること
+        #expect(hotkey.keyEventHandler != nil)
+    }
+
     private func makeInfo(
         title: String,
         label: String = "",

--- a/Tests/VimursorTests/SearchModeControllerTests.swift
+++ b/Tests/VimursorTests/SearchModeControllerTests.swift
@@ -143,7 +143,7 @@ struct SearchModeControllerTests {
         try await Task.sleep(for: .milliseconds(100))
 
         // ESC で searching に戻る（ESC keyCode = 53）
-        let consumed = hotkey.simulateKey(53)
+        let consumed = hotkey.simulateKey(KeyCodeMapping.escapeKeyCode)
         try await Task.sleep(for: .milliseconds(100))
 
         #expect(consumed == true)
@@ -191,7 +191,10 @@ struct SearchModeControllerTests {
 
         // Cmd+<先頭ラベル文字>（修飾キー付き）を送信 — 無視されること
         let firstLabel = LabelGenerator.generateLabels(count: 2)[0]
-        let firstKeyCode = KeyCodeMapping.allMappings.first(where: { $0.value == firstLabel })?.key ?? 3
+        guard let firstKeyCode = KeyCodeMapping.allMappings.first(where: { $0.value == firstLabel })?.key else {
+            Issue.record("KeyCodeMapping に firstLabel '\(firstLabel)' のマッピングが存在しない")
+            return
+        }
         _ = hotkey.simulateKey(firstKeyCode, flags: .maskCommand)
         try await Task.sleep(for: .milliseconds(100))
 
@@ -230,28 +233,39 @@ struct SearchModeControllerTests {
         #expect(hotkey.keyEventHandler == nil)
     }
 
-    @Test("selecting 中の prefix マッチで状態が更新される")
+    @Test("selecting 中の prefix マッチ入力でハンドラが維持される（2文字ラベル）")
     func selectingPrefixMatchUpdatesState() async throws {
-        let elements = [
-            makeSearchInfo(title: "Save"),
-            makeSearchInfo(title: "Save As"),
-            makeSearchInfo(title: "Close")
-        ]
+        // LabelGenerator は 17 件以上で 2 文字ラベルを生成する（chars は 16 文字）
+        let elements = (0..<17).map { makeSearchInfo(title: "Item \($0)") }
         let (controller, overlay, hotkey, fetcher) = makeSUT(elements: elements)
         controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
         try await Task.sleep(for: .milliseconds(100))
 
         guard let searchView = overlay.contentView?.subviews.first(where: { $0 is SearchView }) as? SearchView else {
-            return
+            return  // UI 環境なし（CI等）では SearchView が生成されない
         }
 
-        // Enter で selecting に遷移（ラベルは 2 文字: aa, ab, ba 等）
+        // Enter で selecting に遷移（ラベルは "ff", "fj", "fr", ... の 2 文字）
         searchView.onEnterPressed?()
         try await Task.sleep(for: .milliseconds(100))
 
-        // クリックまたはマッチなしになるまでハンドラが維持されていること
+        // selecting 状態なのでクリックなし・ハンドラが設定されている
         #expect(hotkey.keyEventHandler != nil)
-        // クリックはまだ発生していない
+        #expect(fetcher.clickAtCallCount == 0)
+
+        // 先頭ラベルの 1 文字目を入力（prefix マッチ状態のまま selecting が継続する）
+        let firstLabel = LabelGenerator.generateLabels(count: 17)[0]
+        // firstLabel の 1 文字目 (例: "f") を送信 → prefix マッチが複数残る → deactivate されない
+        let firstChar = String(firstLabel.prefix(1))
+        guard let prefixKeyCode = KeyCodeMapping.allMappings.first(where: { $0.value == firstChar })?.key else {
+            Issue.record("KeyCodeMapping に '\(firstChar)' のマッピングが存在しない")
+            return
+        }
+        _ = hotkey.simulateKey(prefixKeyCode)
+        try await Task.sleep(for: .milliseconds(100))
+
+        // prefix 入力後もハンドラが維持され、クリックが発生していないこと
+        #expect(hotkey.keyEventHandler != nil)
         #expect(fetcher.clickAtCallCount == 0)
     }
 
@@ -277,7 +291,8 @@ struct SearchModeControllerTests {
         // 先頭ラベルと対応する keyCode を動的に解決する
         let firstLabel = LabelGenerator.generateLabels(count: 2)[0]
         guard let keyCode = KeyCodeMapping.allMappings.first(where: { $0.value == firstLabel })?.key else {
-            return  // マッピングが存在しない場合はスキップ
+            Issue.record("KeyCodeMapping に firstLabel '\(firstLabel)' のマッピングが存在しない")
+            return
         }
 
         // 先頭ラベルに完全一致するキーを送信 → クリック
@@ -327,7 +342,7 @@ struct SearchModeControllerTests {
         }
 
         // searching 状態で ESC を送信（keyCode 53）
-        let consumed = hotkey.simulateKey(53)
+        let consumed = hotkey.simulateKey(KeyCodeMapping.escapeKeyCode)
         try await Task.sleep(for: .milliseconds(100))
 
         #expect(consumed == true)
@@ -385,7 +400,7 @@ struct SearchModeControllerTests {
         #expect(hotkey.keyEventHandler != nil)  // selecting ハンドラが設定されている
 
         // ESC で searching に戻る
-        hotkey.simulateKey(53)
+        hotkey.simulateKey(KeyCodeMapping.escapeKeyCode)
         try await Task.sleep(for: .milliseconds(100))
         #expect(hotkey.keyEventHandler != nil)  // searching ハンドラが設定されている
 
@@ -419,7 +434,7 @@ struct SearchModeControllerTests {
         try await Task.sleep(for: .milliseconds(100))
 
         // ESC で searching に戻る
-        hotkey.simulateKey(53)
+        hotkey.simulateKey(KeyCodeMapping.escapeKeyCode)
         try await Task.sleep(for: .milliseconds(100))
 
         // searching 状態に戻っているのでクリックなし・ハンドラ維持


### PR DESCRIPTION
## Summary

- 検索モードで複数マッチ時にヒントラベル（f, j, r, ...）を表示し、ラベル文字入力で対象要素を選択・クリックできるようにした
- `keyCodeToChar` を `KeyCodeMapping` 共通ユーティリティに抽出し、HintMode・SearchMode で共有
- ESC keyCode も `KeyCodeMapping.escapeKeyCode` に共通化

### 状態遷移

```
inactive → fetching → searching → selecting → (click) → inactive
                         ↑            │
                         └── ESC ─────┘  (クエリ維持で戻る)
                         │
                         └── ESC → inactive (検索終了)
```

### 動作

- マッチ1件: Enter で即クリック（従来通り）
- マッチ2件以上: Enter → ラベル表示 → ラベル文字入力でクリック
- ラベル選択中の ESC: 検索入力に戻る（クエリ維持）

Epic: #59

Closes #59, Closes #61, Closes #62, Closes #63, Closes #64, Closes #65

## Test plan

- [x] `swift build` 成功
- [x] `swift test` 全 106 テストパス（SearchModeController カバレッジ 93.5%）
- [x] 手動テスト: マッチ1件 → Enter → 即クリック（回帰）
- [x] 手動テスト: マッチ複数件 → Enter → ラベル表示 → ラベル入力 → クリック
- [x] 手動テスト: ラベル選択中 ESC → 検索入力に戻る（クエリ維持）
- [x] 手動テスト: searching 中 ESC → 完全終了
- [ ] build-dmg.sh 経由の動作確認（translocation の影響で未確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)