### PR TITLE
refactor: コード品質改善（型安全・重複排除・定数管理）(Epic 12)

### DIFF
--- a/Sources/Vimursor/Accessibility/AXAttributes.swift
+++ b/Sources/Vimursor/Accessibility/AXAttributes.swift
@@ -1,0 +1,39 @@
+import AppKit
+
+/// AXUIElement の属性取得を安全に行う共通ユーティリティ。
+/// 座標は AX スクリーン座標系（原点:左上）で返す。
+enum AXAttributes {
+    /// AXUIElement の AXPosition + AXSize から CGRect を取得する。
+    /// - Returns: AX座標（原点:左上）の CGRect。取得失敗時は nil。
+    static func frame(of element: AXUIElement) -> CGRect? {
+        var posRef: CFTypeRef?
+        var sizeRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, "AXPosition" as CFString, &posRef) == .success,
+              AXUIElementCopyAttributeValue(element, "AXSize" as CFString, &sizeRef) == .success,
+              let posRef, let sizeRef else { return nil }
+        return rectFromValues(positionValue: posRef, sizeValue: sizeRef)
+    }
+
+    /// CFTypeRef から CGRect を構築する純粋ロジック（テスト用に分離）。
+    /// - Returns: サイズが 0 以下、または AXValue 型でない場合は nil。
+    static func rectFromValues(positionValue: CFTypeRef, sizeValue: CFTypeRef) -> CGRect? {
+        // CFGetTypeID で AXValue かどうかを確認（条件付き as? は CF 型では常に成功するため使えない）
+        guard CFGetTypeID(positionValue) == AXValueGetTypeID(),
+              CFGetTypeID(sizeValue) == AXValueGetTypeID() else { return nil }
+        // 型チェック済みなので force cast は安全
+        let posVal = positionValue as! AXValue  // swiftlint:disable:this force_cast
+        let sizeVal = sizeValue as! AXValue     // swiftlint:disable:this force_cast
+        var position = CGPoint.zero
+        var size = CGSize.zero
+        guard AXValueGetValue(posVal, .cgPoint, &position),
+              AXValueGetValue(sizeVal, .cgSize, &size) else { return nil }
+        guard size.width > 0, size.height > 0 else { return nil }
+        return CGRect(origin: position, size: size)
+    }
+
+    /// CFTypeRef が AXUIElement かどうかを検証し、安全にキャストする。
+    static func element(from ref: CFTypeRef) -> AXUIElement? {
+        guard CFGetTypeID(ref) == AXUIElementGetTypeID() else { return nil }
+        return (ref as! AXUIElement)  // swiftlint:disable:this force_cast
+    }
+}

--- a/Sources/Vimursor/Accessibility/AXManager.swift
+++ b/Sources/Vimursor/Accessibility/AXManager.swift
@@ -140,26 +140,10 @@ final class AXManager: @unchecked Sendable {
     }
 
     private func fetchFrame(element: AXUIElement, screenHeight: CGFloat) -> CGRect? {
-        var position = CGPoint.zero
-        var size = CGSize.zero
-
-        var posRef: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(element, "AXPosition" as CFString, &posRef) == .success,
-              let posRef else { return nil }
-        let posVal = posRef as! AXValue  // AXValue は CF型なので force cast が正しい
-        AXValueGetValue(posVal, .cgPoint, &position)
-
-        var sizeRef: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(element, "AXSize" as CFString, &sizeRef) == .success,
-              let sizeRef else { return nil }
-        let sizeVal = sizeRef as! AXValue
-        AXValueGetValue(sizeVal, .cgSize, &size)
-
-        guard size.width > 0, size.height > 0 else { return nil }
-
+        guard let axFrame = AXAttributes.frame(of: element) else { return nil }
         // AX座標（原点:左上）→ NSWindow座標（原点:左下）変換
-        let convertedY = screenHeight - position.y - size.height
-        return CGRect(x: position.x, y: convertedY, width: size.width, height: size.height)
+        let convertedY = screenHeight - axFrame.origin.y - axFrame.size.height
+        return CGRect(x: axFrame.origin.x, y: convertedY, width: axFrame.size.width, height: axFrame.size.height)
     }
 }
 

--- a/Sources/Vimursor/Accessibility/UIElementEnumerator.swift
+++ b/Sources/Vimursor/Accessibility/UIElementEnumerator.swift
@@ -1,5 +1,14 @@
 import AppKit
 
+private enum Limits {
+    /// クリック可能要素探索の最大深さ（無限再帰防止）
+    static let clickableMaxDepth = 25
+    /// 検索可能要素探索の最大深さ
+    static let searchableMaxDepth = 30
+    /// 検索可能要素の最大取得数（メモリ保護）
+    static let searchableMaxCount = 3000
+}
+
 enum UIElementEnumerator {
     private static let clickableRoles: Set<String> = [
         "AXButton", "AXLink", "AXCheckBox", "AXRadioButton",
@@ -24,7 +33,7 @@ enum UIElementEnumerator {
         into result: inout [AXUIElement],
         depth: Int
     ) {
-        guard depth < 25 else { return }  // 無限再帰防止
+        guard depth < Limits.clickableMaxDepth else { return }  // 無限再帰防止
 
         if isClickable(element: element) {
             result.append(element)
@@ -74,7 +83,7 @@ enum UIElementEnumerator {
         into result: inout [AXUIElement],
         depth: Int
     ) {
-        guard depth < 30, result.count < 3000 else { return }
+        guard depth < Limits.searchableMaxDepth, result.count < Limits.searchableMaxCount else { return }
 
         var hiddenRef: CFTypeRef?
         if AXUIElementCopyAttributeValue(element, "AXHidden" as CFString, &hiddenRef) == .success,

--- a/Sources/Vimursor/ScrollMode/ScrollTarget.swift
+++ b/Sources/Vimursor/ScrollMode/ScrollTarget.swift
@@ -1,5 +1,18 @@
 import AppKit
 
+private enum Limits {
+    /// 祖先スクロール領域検索の最大深さ
+    static let ancestorMaxDepth = 10
+    /// スクロール可能要素収集の最大深さ
+    static let collectMaxDepth = 20
+    /// 分割ポイント検出の最大深さ
+    static let splitMaxDepth = 5
+    /// スクロール領域として認識する最小サイズ（ポイント）
+    static let minScrollAreaSize: CGFloat = 100
+    /// ラッパー要素判定の幅閾値（親の何割以上か）
+    static let wrapperWidthRatio: CGFloat = 0.9
+}
+
 enum ScrollTarget {
     private static let scrollableRoles: Set<String> = [
         "AXScrollArea", "AXWebArea", "AXTextArea", "AXList", "AXTable", "AXOutline"
@@ -10,8 +23,8 @@ enum ScrollTarget {
     static func findScrollableElement(in app: AXUIElement) -> AXUIElement? {
         var focusedRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(app, "AXFocusedUIElement" as CFString, &focusedRef) == .success,
-              let focusedRef else { return nil }
-        let focused = focusedRef as! AXUIElement
+              let focusedRef,
+              let focused = AXAttributes.element(from: focusedRef) else { return nil }
 
         if isScrollable(element: focused) { return focused }
         return findScrollableAncestor(of: focused, depth: 0)
@@ -25,11 +38,11 @@ enum ScrollTarget {
     }
 
     private static func findScrollableAncestor(of element: AXUIElement, depth: Int) -> AXUIElement? {
-        guard depth < 10 else { return nil }
+        guard depth < Limits.ancestorMaxDepth else { return nil }
         var parentRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(element, "AXParent" as CFString, &parentRef) == .success,
-              let parentRef else { return nil }
-        let parent = parentRef as! AXUIElement
+              let parentRef,
+              let parent = AXAttributes.element(from: parentRef) else { return nil }
         if isScrollable(element: parent) { return parent }
         return findScrollableAncestor(of: parent, depth: depth + 1)
     }
@@ -37,19 +50,8 @@ enum ScrollTarget {
     /// AXUIElement の中心点をスクリーン座標系（原点:左上）で返す
     /// CGEvent.location にそのまま使える（NSWindow座標変換は不要）
     static func centerPoint(of element: AXUIElement) -> CGPoint? {
-        var posRef: CFTypeRef?
-        var sizeRef: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(element, "AXPosition" as CFString, &posRef) == .success,
-              AXUIElementCopyAttributeValue(element, "AXSize" as CFString, &sizeRef) == .success,
-              let posRef, let sizeRef else { return nil }
-
-        var position = CGPoint.zero
-        var size = CGSize.zero
-        AXValueGetValue(posRef as! AXValue, .cgPoint, &position)
-        AXValueGetValue(sizeRef as! AXValue, .cgSize, &size)
-
-        guard size.width > 0, size.height > 0 else { return nil }
-        return CGPoint(x: position.x + size.width / 2, y: position.y + size.height / 2)
+        guard let frame = AXAttributes.frame(of: element) else { return nil }
+        return CGPoint(x: frame.midX, y: frame.midY)
     }
 
     // MARK: - 全スクロール領域列挙
@@ -63,17 +65,17 @@ enum ScrollTarget {
         return result
     }
 
-    private static let minScrollAreaSize: CGFloat = 100
-
     private static func collectScrollable(
         element: AXUIElement,
         into result: inout [ScrollAreaInfo],
         depth: Int
     ) {
-        guard depth < 20 else { return }
+        guard depth < Limits.collectMaxDepth else { return }
 
         let selfIsScrollable = isScrollable(element: element)
-            && axFrame(of: element).map { $0.width >= minScrollAreaSize && $0.height >= minScrollAreaSize } ?? false
+            && AXAttributes.frame(of: element).map {
+                $0.width >= Limits.minScrollAreaSize && $0.height >= Limits.minScrollAreaSize
+            } ?? false
 
         // 子を先に探索（自身がスクロール可能でも止めない）
         let countBefore = result.count
@@ -87,12 +89,12 @@ enum ScrollTarget {
         let childrenAdded = result.count > countBefore
 
         if selfIsScrollable {
-            if !childrenAdded, let f = axFrame(of: element) {
+            if !childrenAdded, let f = AXAttributes.frame(of: element) {
                 // リーフ: そのまま追加
                 let center = CGPoint(x: f.midX, y: f.midY)
                 let label = String(result.count + 1)
                 result.append(ScrollAreaInfo(frame: f, centerPoint: center, label: label))
-            } else if childrenAdded, let parentFrame = axFrame(of: element) {
+            } else if childrenAdded, let parentFrame = AXAttributes.frame(of: element) {
                 // 補完検出: 子にスクロール領域があるが、カバーされていない分割領域も追加
                 let addedAreas = Array(result[countBefore..<result.count])
                 addComplementRegions(element: element, parentFrame: parentFrame, existingAreas: addedAreas, into: &result)
@@ -108,7 +110,7 @@ enum ScrollTarget {
         existingAreas: [ScrollAreaInfo],
         into result: inout [ScrollAreaInfo]
     ) {
-        let splitChildren = findSplitChildren(element: element, parentFrame: parentFrame, maxDepth: 5)
+        let splitChildren = findSplitChildren(element: element, parentFrame: parentFrame, maxDepth: Limits.splitMaxDepth)
         guard splitChildren.count >= 2 else { return }
 
         for childFrame in splitChildren {
@@ -138,13 +140,15 @@ enum ScrollTarget {
         // 子のうちサイズが十分なものだけ取得
         var significantChildren: [(element: AXUIElement, frame: CGRect)] = []
         for child in children {
-            if let f = axFrame(of: child), f.width >= minScrollAreaSize, f.height >= minScrollAreaSize {
+            if let f = AXAttributes.frame(of: child),
+               f.width >= Limits.minScrollAreaSize,
+               f.height >= Limits.minScrollAreaSize {
                 significantChildren.append((child, f))
             }
         }
 
-        // 親と同サイズ（幅が90%以上）の子はラッパーとみなしてスキップ
-        let nonWrappers = significantChildren.filter { $0.frame.width < parentFrame.width * 0.9 }
+        // 親と同サイズ（幅が wrapperWidthRatio 以上）の子はラッパーとみなしてスキップ
+        let nonWrappers = significantChildren.filter { $0.frame.width < parentFrame.width * Limits.wrapperWidthRatio }
 
         if nonWrappers.count >= 2 {
             // 分割ポイント発見
@@ -152,7 +156,7 @@ enum ScrollTarget {
         }
 
         // ラッパー（親と同サイズの子）がある場合、その中を再帰探索
-        for (child, frame) in significantChildren where frame.width >= parentFrame.width * 0.9 {
+        for (child, frame) in significantChildren where frame.width >= parentFrame.width * Limits.wrapperWidthRatio {
             let result = findSplitChildren(element: child, parentFrame: parentFrame, maxDepth: maxDepth - 1)
             if result.count >= 2 { return result }
         }
@@ -160,18 +164,4 @@ enum ScrollTarget {
         return []
     }
 
-    /// AX スクリーン座標系（原点:左上）での要素フレームを返す
-    private static func axFrame(of element: AXUIElement) -> CGRect? {
-        var posRef: CFTypeRef?
-        var sizeRef: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(element, "AXPosition" as CFString, &posRef) == .success,
-              AXUIElementCopyAttributeValue(element, "AXSize" as CFString, &sizeRef) == .success,
-              let posRef, let sizeRef else { return nil }
-        var position = CGPoint.zero
-        var size = CGSize.zero
-        AXValueGetValue(posRef as! AXValue, .cgPoint, &position)
-        AXValueGetValue(sizeRef as! AXValue, .cgSize, &size)
-        guard size.width > 0, size.height > 0 else { return nil }
-        return CGRect(origin: position, size: size)
-    }
 }

--- a/Sources/Vimursor/ScrollMode/ScrollTarget.swift
+++ b/Sources/Vimursor/ScrollMode/ScrollTarget.swift
@@ -72,8 +72,9 @@ enum ScrollTarget {
     ) {
         guard depth < Limits.collectMaxDepth else { return }
 
+        let frame = AXAttributes.frame(of: element)
         let selfIsScrollable = isScrollable(element: element)
-            && AXAttributes.frame(of: element).map {
+            && frame.map {
                 $0.width >= Limits.minScrollAreaSize && $0.height >= Limits.minScrollAreaSize
             } ?? false
 
@@ -88,16 +89,16 @@ enum ScrollTarget {
         }
         let childrenAdded = result.count > countBefore
 
-        if selfIsScrollable {
-            if !childrenAdded, let f = AXAttributes.frame(of: element) {
+        if selfIsScrollable, let f = frame {
+            if !childrenAdded {
                 // リーフ: そのまま追加
                 let center = CGPoint(x: f.midX, y: f.midY)
                 let label = String(result.count + 1)
                 result.append(ScrollAreaInfo(frame: f, centerPoint: center, label: label))
-            } else if childrenAdded, let parentFrame = AXAttributes.frame(of: element) {
+            } else {
                 // 補完検出: 子にスクロール領域があるが、カバーされていない分割領域も追加
                 let addedAreas = Array(result[countBefore..<result.count])
-                addComplementRegions(element: element, parentFrame: parentFrame, existingAreas: addedAreas, into: &result)
+                addComplementRegions(element: element, parentFrame: f, existingAreas: addedAreas, into: &result)
             }
         }
     }

--- a/Tests/VimursorTests/AXAttributesTests.swift
+++ b/Tests/VimursorTests/AXAttributesTests.swift
@@ -1,0 +1,92 @@
+import Testing
+import AppKit
+@testable import Vimursor
+
+@Suite("AXAttributes Tests")
+struct AXAttributesTests {
+
+    // MARK: - rectFromValues
+
+    @Test("正常系: 有効な position + size → CGRect が返る")
+    func rectFromValidValues() {
+        var point = CGPoint(x: 100, y: 200)
+        let posValue = AXValueCreate(.cgPoint, &point)! as CFTypeRef
+
+        var size = CGSize(width: 300, height: 400)
+        let sizeValue = AXValueCreate(.cgSize, &size)! as CFTypeRef
+
+        let rect = AXAttributes.rectFromValues(positionValue: posValue, sizeValue: sizeValue)
+
+        #expect(rect != nil)
+        #expect(rect?.origin.x == 100)
+        #expect(rect?.origin.y == 200)
+        #expect(rect?.size.width == 300)
+        #expect(rect?.size.height == 400)
+    }
+
+    @Test("ゼロ幅 → nil が返る")
+    func zeroWidthReturnsNil() {
+        var point = CGPoint(x: 0, y: 0)
+        let posValue = AXValueCreate(.cgPoint, &point)! as CFTypeRef
+
+        var size = CGSize(width: 0, height: 100)
+        let sizeValue = AXValueCreate(.cgSize, &size)! as CFTypeRef
+
+        let rect = AXAttributes.rectFromValues(positionValue: posValue, sizeValue: sizeValue)
+        #expect(rect == nil)
+    }
+
+    @Test("ゼロ高さ → nil が返る")
+    func zeroHeightReturnsNil() {
+        var point = CGPoint(x: 0, y: 0)
+        let posValue = AXValueCreate(.cgPoint, &point)! as CFTypeRef
+
+        var size = CGSize(width: 100, height: 0)
+        let sizeValue = AXValueCreate(.cgSize, &size)! as CFTypeRef
+
+        let rect = AXAttributes.rectFromValues(positionValue: posValue, sizeValue: sizeValue)
+        #expect(rect == nil)
+    }
+
+    @Test("両方ゼロサイズ → nil が返る")
+    func bothZeroSizeReturnsNil() {
+        var point = CGPoint(x: 10, y: 20)
+        let posValue = AXValueCreate(.cgPoint, &point)! as CFTypeRef
+
+        var size = CGSize(width: 0, height: 0)
+        let sizeValue = AXValueCreate(.cgSize, &size)! as CFTypeRef
+
+        let rect = AXAttributes.rectFromValues(positionValue: posValue, sizeValue: sizeValue)
+        #expect(rect == nil)
+    }
+
+    @Test("不正な CFTypeRef (AXValue でない文字列) → nil が返る")
+    func invalidCFTypeRefReturnsNil() {
+        let notAXValue = "not an AXValue" as CFTypeRef
+
+        var point = CGPoint(x: 100, y: 200)
+        let posValue = AXValueCreate(.cgPoint, &point)! as CFTypeRef
+
+        // positionValue が不正
+        let rect1 = AXAttributes.rectFromValues(positionValue: notAXValue, sizeValue: posValue)
+        #expect(rect1 == nil)
+
+        // sizeValue が不正
+        let rect2 = AXAttributes.rectFromValues(positionValue: posValue, sizeValue: notAXValue)
+        #expect(rect2 == nil)
+    }
+
+    @Test("負の座標でも有効なサイズなら CGRect が返る")
+    func negativeOriginWithValidSize() {
+        var point = CGPoint(x: -50, y: -100)
+        let posValue = AXValueCreate(.cgPoint, &point)! as CFTypeRef
+
+        var size = CGSize(width: 200, height: 150)
+        let sizeValue = AXValueCreate(.cgSize, &size)! as CFTypeRef
+
+        let rect = AXAttributes.rectFromValues(positionValue: posValue, sizeValue: sizeValue)
+        #expect(rect != nil)
+        #expect(rect?.origin.x == -50)
+        #expect(rect?.origin.y == -100)
+    }
+}


### PR DESCRIPTION
## Summary

- AX属性取得（AXPosition + AXSize → CGRect）の重複3箇所を `AXAttributes` enum に集約
- `as! AXValue` / `as! AXUIElement` の force cast を `CFGetTypeID` チェック付きの安全な実装に置換
- `AXValueGetValue` の戻り値チェックを追加
- UIElementEnumerator / ScrollTarget のマジックナンバーを `private enum Limits` に定数化

Epic: #71
Closes #71, Closes #72, Closes #73, Closes #74

## Test plan

- [x] `swift build` ビルド成功
- [x] `swift test` 128件全パス（AXAttributes 新規テスト6件含む）
- [ ] ヒントモード手動動作確認（座標変換の回帰）
- [ ] 検索モード手動動作確認
- [ ] スクロールモード手動動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)