### PR TITLE
feat: ショートカット設定 UX 改善 (Epic 13)

### DIFF
--- a/Sources/Vimursor/Settings/ShortcutNames.swift
+++ b/Sources/Vimursor/Settings/ShortcutNames.swift
@@ -6,10 +6,10 @@ extension KeyboardShortcuts.Name {
     // KeyboardShortcuts.Name が Sendable 非準拠のため暫定対応 (KeyboardShortcuts v1.x)
     // ライブラリ側が Sendable 準拠した場合は nonisolated(unsafe) と @preconcurrency を削除すること
 
-    /// ヒントモード起動ショートカット（デフォルト: Cmd+Shift+Space）
+    /// ヒントモード起動ショートカット（デフォルト: Cmd+Shift+F）
     nonisolated(unsafe) static let hintMode = Self(
         "hintMode",
-        default: .init(.space, modifiers: [.command, .shift])
+        default: .init(.f, modifiers: [.command, .shift])
     )
 
     /// 検索モード起動ショートカット（デフォルト: Cmd+Shift+/）

--- a/Sources/Vimursor/Settings/ShortcutRecorderField.swift
+++ b/Sources/Vimursor/Settings/ShortcutRecorderField.swift
@@ -1,0 +1,197 @@
+import AppKit
+import Carbon.HIToolbox
+@preconcurrency import KeyboardShortcuts
+
+// MARK: - Key Codes
+
+private enum KeyCode {
+    static let escape: UInt16 = 53
+    static let delete: UInt16 = 51
+    static let deleteForward: UInt16 = 117
+}
+
+// MARK: - ShortcutRecorderField
+
+/// RecorderCocoa の衝突チェックを除去した独自キーボードショートカット入力フィールド。
+/// Shift のみの修飾キーは無効。Shift 以外の修飾キーが必要。
+@MainActor
+final class ShortcutRecorderField: NSSearchField, NSSearchFieldDelegate {
+
+    // MARK: - Constants
+
+    private enum Placeholder {
+        static let idle = "Click to record"
+        static let recording = "Press Shortcut"
+    }
+
+    private let minimumWidth: CGFloat = 160
+
+    // MARK: - State
+
+    private let shortcutName: KeyboardShortcuts.Name
+    private var eventMonitor: Any?
+    private var shortcutChangeObserver: NSObjectProtocol?
+    private var cancelButtonCell: NSButtonCell?
+
+    // MARK: - Init
+
+    init(for name: KeyboardShortcuts.Name) {
+        self.shortcutName = name
+        super.init(frame: .zero)
+        delegate = self
+        placeholderString = Placeholder.idle
+        alignment = .center
+        (cell as? NSSearchFieldCell)?.searchButtonCell = nil
+        wantsLayer = true
+        setContentHuggingPriority(.defaultHigh, for: .vertical)
+        setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        cancelButtonCell = (cell as? NSSearchFieldCell)?.cancelButtonCell
+        refreshDisplay()
+        setUpObserver()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) not supported") }
+
+    // MARK: - Intrinsic Size
+
+    override var intrinsicContentSize: CGSize {
+        var size = super.intrinsicContentSize
+        size.width = minimumWidth
+        return size
+    }
+
+    // MARK: - Display Helpers
+
+    /// nil ショートカットを空文字列に変換して返す（テスト可能な純粋関数）。
+    nonisolated static func displayString(for shortcut: KeyboardShortcuts.Shortcut?) -> String {
+        shortcut.map { "\($0)" } ?? ""
+    }
+
+    /// Shift のみの修飾キーは無効。Shift 以外が少なくとも 1 つ必要。
+    nonisolated static func isValidModifiers(_ flags: NSEvent.ModifierFlags) -> Bool {
+        !flags.subtracting(.shift).isEmpty
+    }
+
+    // MARK: - Private Helpers
+
+    private var showsCancelButton: Bool {
+        get { (cell as? NSSearchFieldCell)?.cancelButtonCell != nil }
+        set { (cell as? NSSearchFieldCell)?.cancelButtonCell = newValue ? cancelButtonCell : nil }
+    }
+
+    private func refreshDisplay() {
+        let shortcut = KeyboardShortcuts.getShortcut(for: shortcutName)
+        stringValue = Self.displayString(for: shortcut)
+        showsCancelButton = !stringValue.isEmpty
+    }
+
+    private func setUpObserver() {
+        let notificationName = Notification.Name("KeyboardShortcuts_shortcutByNameDidChange")
+        shortcutChangeObserver = NotificationCenter.default.addObserver(
+            forName: notificationName,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard
+                let self,
+                let name = notification.userInfo?["name"] as? KeyboardShortcuts.Name,
+                name == self.shortcutName
+            else { return }
+            self.refreshDisplay()
+        }
+    }
+
+    private func endRecording() {
+        if let monitor = eventMonitor {
+            NSEvent.removeMonitor(monitor)
+            eventMonitor = nil
+        }
+        placeholderString = Placeholder.idle
+        showsCancelButton = !stringValue.isEmpty
+        // ショートカット監視を再開
+        KeyboardShortcuts.isEnabled = true
+    }
+
+    private func saveShortcut(_ shortcut: KeyboardShortcuts.Shortcut?) {
+        KeyboardShortcuts.setShortcut(shortcut, for: shortcutName)
+    }
+
+    private func clearShortcut() {
+        saveShortcut(nil)
+        stringValue = ""
+        showsCancelButton = false
+        window?.makeFirstResponder(nil)
+    }
+
+    // MARK: - First Responder
+
+    override func becomeFirstResponder() -> Bool {
+        guard super.becomeFirstResponder() else { return false }
+
+        placeholderString = Placeholder.recording
+        showsCancelButton = !stringValue.isEmpty
+        // 録音中は誤ってショートカットが発火しないよう監視を一時停止
+        KeyboardShortcuts.isEnabled = false
+
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { [weak self] event in
+            guard let self else { return event }
+            return self.handleKeyDown(event)
+        }
+
+        return true
+    }
+
+    override func resignFirstResponder() -> Bool {
+        let result = super.resignFirstResponder()
+        endRecording()
+        return result
+    }
+
+    // MARK: - Key Handling
+
+    private func handleKeyDown(_ event: NSEvent) -> NSEvent? {
+        let modifiers = event.modifierFlags.intersection([.command, .shift, .option, .control])
+
+        // Escape: キャンセル
+        if modifiers.isEmpty, event.keyCode == KeyCode.escape {
+            window?.makeFirstResponder(nil)
+            return nil
+        }
+
+        // Delete / Backspace: クリア
+        if modifiers.isEmpty,
+           event.keyCode == KeyCode.delete || event.keyCode == KeyCode.deleteForward {
+            clearShortcut()
+            return nil
+        }
+
+        // 修飾キー検証
+        guard Self.isValidModifiers(modifiers),
+              let shortcut = KeyboardShortcuts.Shortcut(event: event)
+        else {
+            NSSound.beep()
+            return nil
+        }
+
+        // ショートカットを保存
+        stringValue = Self.displayString(for: shortcut)
+        showsCancelButton = true
+        saveShortcut(shortcut)
+        window?.makeFirstResponder(nil)
+        return nil
+    }
+
+    // MARK: - NSSearchFieldDelegate
+
+    func controlTextDidChange(_ object: Notification) {
+        showsCancelButton = !stringValue.isEmpty
+        if stringValue.isEmpty {
+            saveShortcut(nil)
+        }
+    }
+
+    func controlTextDidEndEditing(_ object: Notification) {
+        endRecording()
+    }
+}

--- a/Sources/Vimursor/Settings/ShortcutRecorderField.swift
+++ b/Sources/Vimursor/Settings/ShortcutRecorderField.swift
@@ -88,6 +88,7 @@ final class ShortcutRecorderField: NSSearchField, NSSearchFieldDelegate {
 
     private func setUpObserver() {
         let notificationName = Notification.Name("KeyboardShortcuts_shortcutByNameDidChange")
+        let expectedName = shortcutName
         shortcutChangeObserver = NotificationCenter.default.addObserver(
             forName: notificationName,
             object: nil,
@@ -96,9 +97,11 @@ final class ShortcutRecorderField: NSSearchField, NSSearchFieldDelegate {
             guard
                 let self,
                 let name = notification.userInfo?["name"] as? KeyboardShortcuts.Name,
-                name == self.shortcutName
+                name == expectedName
             else { return }
-            self.refreshDisplay()
+            MainActor.assumeIsolated {
+                self.refreshDisplay()
+            }
         }
     }
 

--- a/Sources/Vimursor/Settings/ShortcutRecorderField.swift
+++ b/Sources/Vimursor/Settings/ShortcutRecorderField.swift
@@ -5,9 +5,9 @@ import Carbon.HIToolbox
 // MARK: - Key Codes
 
 private enum KeyCode {
-    static let escape: UInt16 = 53
-    static let delete: UInt16 = 51
-    static let deleteForward: UInt16 = 117
+    static let escape: UInt16 = UInt16(kVK_Escape)
+    static let delete: UInt16 = UInt16(kVK_Delete)
+    static let deleteForward: UInt16 = UInt16(kVK_ForwardDelete)
 }
 
 // MARK: - ShortcutRecorderField
@@ -29,8 +29,9 @@ final class ShortcutRecorderField: NSSearchField, NSSearchFieldDelegate {
     // MARK: - State
 
     private let shortcutName: KeyboardShortcuts.Name
-    private var eventMonitor: Any?
-    private var shortcutChangeObserver: NSObjectProtocol?
+    // nonisolated(unsafe) により deinit からのアクセスを可能にする（NSEvent / NotificationCenter API はスレッドセーフ）
+    nonisolated(unsafe) private var eventMonitor: Any?
+    nonisolated(unsafe) private var shortcutChangeObserver: NSObjectProtocol?
     private var cancelButtonCell: NSButtonCell?
 
     // MARK: - Init
@@ -52,6 +53,15 @@ final class ShortcutRecorderField: NSSearchField, NSSearchFieldDelegate {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("init(coder:) not supported") }
+
+    deinit {
+        if let observer = shortcutChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let monitor = eventMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+    }
 
     // MARK: - Intrinsic Size
 
@@ -137,6 +147,11 @@ final class ShortcutRecorderField: NSSearchField, NSSearchFieldDelegate {
         // 録音中は誤ってショートカットが発火しないよう監視を一時停止
         KeyboardShortcuts.isEnabled = false
 
+        // 既存の monitor を先に解除してから新規登録（二重登録防止）
+        if let existing = eventMonitor {
+            NSEvent.removeMonitor(existing)
+            eventMonitor = nil
+        }
         eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { [weak self] event in
             guard let self else { return event }
             return self.handleKeyDown(event)

--- a/Sources/Vimursor/Settings/ShortcutsSettingsView.swift
+++ b/Sources/Vimursor/Settings/ShortcutsSettingsView.swift
@@ -4,7 +4,7 @@ import KeyboardShortcuts
 // MARK: - ShortcutsSettingsView
 
 /// Shortcuts タブのコンテンツビュー。
-/// ヒント／検索／スクロールモードの起動ショートカットを RecorderCocoa でカスタマイズできる。
+/// ヒント／検索／スクロールモードの起動ショートカットを ShortcutRecorderField でカスタマイズできる。
 @MainActor
 final class ShortcutsSettingsView: NSView {
 
@@ -20,9 +20,9 @@ final class ShortcutsSettingsView: NSView {
 
     // MARK: - Recorders
 
-    private let hintModeRecorder = KeyboardShortcuts.RecorderCocoa(for: .hintMode)
-    private let searchModeRecorder = KeyboardShortcuts.RecorderCocoa(for: .searchMode)
-    private let scrollModeRecorder = KeyboardShortcuts.RecorderCocoa(for: .scrollMode)
+    private let hintModeRecorder = ShortcutRecorderField(for: .hintMode)
+    private let searchModeRecorder = ShortcutRecorderField(for: .searchMode)
+    private let scrollModeRecorder = ShortcutRecorderField(for: .scrollMode)
 
     // MARK: - Initialization
 
@@ -37,7 +37,7 @@ final class ShortcutsSettingsView: NSView {
     // MARK: - Setup
 
     private func setupLayout() {
-        let rows: [(String, KeyboardShortcuts.RecorderCocoa)] = [
+        let rows: [(String, ShortcutRecorderField)] = [
             ("Hint Mode:", hintModeRecorder),
             ("Search Mode:", searchModeRecorder),
             ("Scroll Mode:", scrollModeRecorder)
@@ -77,8 +77,8 @@ final class ShortcutsSettingsView: NSView {
 
     // MARK: - Public
 
-    /// KeyboardShortcuts.reset() は UserDefaults を更新し、RecorderCocoa は
-    /// NSUserDefaultsDidChangeNotification を監視して自動的に表示を更新する。
+    /// KeyboardShortcuts.reset() は UserDefaults を更新し、ShortcutRecorderField は
+    /// KeyboardShortcuts_shortcutByNameDidChange 通知を監視して自動的に表示を更新する。
     /// 明示的な操作は不要。このメソッドは AppearanceSettingsView / BehaviorSettingsView
     /// との API 対称性のために提供する。
     func reloadValues() {}

--- a/Sources/Vimursor/StatusBarController.swift
+++ b/Sources/Vimursor/StatusBarController.swift
@@ -226,6 +226,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         // setShortcut(for:) が "/" + [.command, .shift] を設定するため、
         // "?" + [.command] に補正して ⌘⇧/ を正しく表示させる。
         if let item = menu.item(withTag: MenuItemTag.searchMode),
+           item.keyEquivalentModifierMask.contains(.command),
            item.keyEquivalentModifierMask.contains(.shift),
            item.keyEquivalent == "/" {
             item.keyEquivalent = "?"

--- a/Sources/Vimursor/StatusBarController.swift
+++ b/Sources/Vimursor/StatusBarController.swift
@@ -222,6 +222,16 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         // メニューが開いている間は Carbon ホットキーをバッファしないよう無効化する
         KeyboardShortcuts.disable(.hintMode, .searchMode, .scrollMode)
 
+        // macOS のメニュー描画エンジンは Shift+記号キー（例: Shift+/）の表示を正しく描画できない。
+        // setShortcut(for:) が "/" + [.command, .shift] を設定するため、
+        // "?" + [.command] に補正して ⌘⇧/ を正しく表示させる。
+        if let item = menu.item(withTag: MenuItemTag.searchMode),
+           item.keyEquivalentModifierMask.contains(.shift),
+           item.keyEquivalent == "/" {
+            item.keyEquivalent = "?"
+            item.keyEquivalentModifierMask.remove(.shift)
+        }
+
         if let item = menu.item(withTag: MenuItemTag.continuousHintMode) {
             item.state = settings.isContinuousMode ? .on : .off
         }

--- a/Tests/VimursorTests/ShortcutRecorderFieldTests.swift
+++ b/Tests/VimursorTests/ShortcutRecorderFieldTests.swift
@@ -1,0 +1,67 @@
+import Testing
+import AppKit
+@testable import Vimursor
+
+// MARK: - ShortcutRecorderField Validation Logic Tests
+
+@Suite("ShortcutRecorderField Tests")
+struct ShortcutRecorderFieldTests {
+
+    // MARK: - isValidModifiers
+
+    @Test("Shift のみは無効")
+    func shiftOnlyIsInvalid() {
+        let flags: NSEvent.ModifierFlags = [.shift]
+        #expect(ShortcutRecorderField.isValidModifiers(flags) == false)
+    }
+
+    @Test("修飾キーなしは無効")
+    func noModifiersIsInvalid() {
+        let flags: NSEvent.ModifierFlags = []
+        #expect(ShortcutRecorderField.isValidModifiers(flags) == false)
+    }
+
+    @Test("Cmd+Shift は有効")
+    func cmdShiftIsValid() {
+        let flags: NSEvent.ModifierFlags = [.command, .shift]
+        #expect(ShortcutRecorderField.isValidModifiers(flags) == true)
+    }
+
+    @Test("Cmd のみは有効")
+    func cmdOnlyIsValid() {
+        let flags: NSEvent.ModifierFlags = [.command]
+        #expect(ShortcutRecorderField.isValidModifiers(flags) == true)
+    }
+
+    @Test("Option のみは有効")
+    func optionOnlyIsValid() {
+        let flags: NSEvent.ModifierFlags = [.option]
+        #expect(ShortcutRecorderField.isValidModifiers(flags) == true)
+    }
+
+    @Test("Control のみは有効")
+    func controlOnlyIsValid() {
+        let flags: NSEvent.ModifierFlags = [.control]
+        #expect(ShortcutRecorderField.isValidModifiers(flags) == true)
+    }
+
+    @Test("Cmd+Option は有効")
+    func cmdOptionIsValid() {
+        let flags: NSEvent.ModifierFlags = [.command, .option]
+        #expect(ShortcutRecorderField.isValidModifiers(flags) == true)
+    }
+
+    @Test("Shift+Option は有効（Shift 以外の修飾キーがある）")
+    func shiftOptionIsValid() {
+        let flags: NSEvent.ModifierFlags = [.shift, .option]
+        #expect(ShortcutRecorderField.isValidModifiers(flags) == true)
+    }
+
+    // MARK: - displayString
+
+    @Test("nil ショートカット → 空文字列")
+    func nilShortcutDisplayString() {
+        let str = ShortcutRecorderField.displayString(for: nil)
+        #expect(str == "")
+    }
+}


### PR DESCRIPTION
## 概要

メニューバーの Search Mode ショートカット表示バグの修正、設定ウィンドウでの衝突警告ポップアップ除去、ヒントモードデフォルトキー変更。

## 変更内容

- Search Mode の menuWillOpen で keyEquivalent を Shift+/ → ? に補正し、メニューバーに正しく表示されるよう修正
- RecorderCocoa を独自 ShortcutRecorderField に置き換え、システムショートカット・メインメニューとの衝突チェックを除去
- ヒントモードのデフォルトショートカットを Cmd+Shift+Space → Cmd+Shift+F に変更

## 関連 Issue

Epic: #76
Closes #76, Closes #77, Closes #78, Closes #39

## テスト

- [x] `swift build` が通ることを確認した
- [x] `swift test` が通ることを確認した
- [x] 手動動作確認済み

## チェックリスト

- [x] コミットメッセージが規則に従っている
- [ ] `release/**` → `main` の PR の場合、開発用ファイル（`.claude/`, `CLAUDE.md`）を削除している