### PR TITLE
feat: ヒントラベルを要素の左端・縦中央に配置 (Epic 14)

### DIFF
--- a/Sources/Vimursor/HintMode/HintView.swift
+++ b/Sources/Vimursor/HintMode/HintView.swift
@@ -41,7 +41,7 @@ final class HintView: NSView {
 
     /// ラベルボックスの origin を計算する純粋関数。
     /// NSWindow 座標系（原点: 左下）で、要素の左端・縦中央にラベルを配置する。
-    static func labelOrigin(elementFrame: CGRect, boxHeight: CGFloat) -> CGPoint {
+    nonisolated static func labelOrigin(elementFrame: CGRect, boxHeight: CGFloat) -> CGPoint {
         CGPoint(
             x: elementFrame.minX,
             y: elementFrame.midY - boxHeight / 2

--- a/Sources/Vimursor/HintMode/HintView.swift
+++ b/Sources/Vimursor/HintMode/HintView.swift
@@ -39,6 +39,15 @@ final class HintView: NSView {
         }
     }
 
+    /// ラベルボックスの origin を計算する純粋関数。
+    /// NSWindow 座標系（原点: 左下）で、要素の左端・縦中央にラベルを配置する。
+    static func labelOrigin(elementFrame: CGRect, boxHeight: CGFloat) -> CGPoint {
+        CGPoint(
+            x: elementFrame.minX,
+            y: elementFrame.midY - boxHeight / 2
+        )
+    }
+
     private func drawLabel(hint: UIElementInfo, isMatch: Bool) {
         let label = hint.label
         let font = NSFont.systemFont(ofSize: settings.labelFontSize, weight: .semibold)
@@ -53,8 +62,8 @@ final class HintView: NSView {
         let boxWidth = size.width + padding * 2
         let boxHeight = size.height + padding * 2
 
-        // ラベルをUI要素の左上に配置
-        let origin = CGPoint(x: hint.frame.minX, y: hint.frame.maxY)
+        // ラベルをUI要素の左端・縦中央に配置（Vimiumスタイル）
+        let origin = HintView.labelOrigin(elementFrame: hint.frame, boxHeight: boxHeight)
         let boxRect = CGRect(x: origin.x, y: origin.y, width: boxWidth, height: boxHeight)
 
         let cornerRadius = HintLabelLayout.cornerRadius

--- a/Tests/VimursorTests/HintViewTests.swift
+++ b/Tests/VimursorTests/HintViewTests.swift
@@ -1,0 +1,61 @@
+import Testing
+import AppKit
+@testable import Vimursor
+
+@Suite("HintView Tests")
+struct HintViewTests {
+
+    // MARK: - labelOrigin
+
+    @Test("通常フレーム: x は minX、y は midY - boxHeight/2")
+    func normalFrame() {
+        // 要素フレーム: x=100, y=200, width=80, height=40
+        // midY = 200 + 40/2 = 220
+        // boxHeight = 20
+        // 期待 origin: (100, 220 - 10) = (100, 210)
+        let frame = CGRect(x: 100, y: 200, width: 80, height: 40)
+        let boxHeight: CGFloat = 20
+        let origin = HintView.labelOrigin(elementFrame: frame, boxHeight: boxHeight)
+        #expect(origin.x == 100)
+        #expect(origin.y == 210)
+    }
+
+    @Test("小さい要素: boxHeight が要素高さより大きい場合も midY 基準で計算される")
+    func smallElement() {
+        // 要素フレーム: x=50, y=100, width=30, height=10
+        // midY = 100 + 10/2 = 105
+        // boxHeight = 20 (要素高さより大きい)
+        // 期待 origin: (50, 105 - 10) = (50, 95)
+        let frame = CGRect(x: 50, y: 100, width: 30, height: 10)
+        let boxHeight: CGFloat = 20
+        let origin = HintView.labelOrigin(elementFrame: frame, boxHeight: boxHeight)
+        #expect(origin.x == 50)
+        #expect(origin.y == 95)
+    }
+
+    @Test("ゼロ起点フレーム: origin が (0, 0) の要素")
+    func zeroOriginFrame() {
+        // 要素フレーム: x=0, y=0, width=100, height=50
+        // midY = 25
+        // boxHeight = 16
+        // 期待 origin: (0, 25 - 8) = (0, 17)
+        let frame = CGRect(x: 0, y: 0, width: 100, height: 50)
+        let boxHeight: CGFloat = 16
+        let origin = HintView.labelOrigin(elementFrame: frame, boxHeight: boxHeight)
+        #expect(origin.x == 0)
+        #expect(origin.y == 17)
+    }
+
+    @Test("正方形要素: 縦中央が正確に計算される")
+    func squareElement() {
+        // 要素フレーム: x=10, y=10, width=60, height=60
+        // midY = 10 + 30 = 40
+        // boxHeight = 22
+        // 期待 origin: (10, 40 - 11) = (10, 29)
+        let frame = CGRect(x: 10, y: 10, width: 60, height: 60)
+        let boxHeight: CGFloat = 22
+        let origin = HintView.labelOrigin(elementFrame: frame, boxHeight: boxHeight)
+        #expect(origin.x == 10)
+        #expect(origin.y == 29)
+    }
+}


### PR DESCRIPTION
## 概要

ヒントモードのラベル位置を要素の左上外側から左端・縦中央（Vimium スタイル）に変更。密集箇所でラベルと要素の対応がわかりやすくなる。

## 変更内容

- `HintView.drawLabel` の origin 計算を `(minX, maxY)` → `(minX, midY - boxHeight/2)` に変更
- `labelOrigin(elementFrame:boxHeight:)` を static 純粋関数として抽出
- `HintViewTests.swift` に4テストケース追加（通常フレーム、小さい要素、ゼロ起点、正方形）

## 関連 Issue

Epic: #81
Closes #82, Closes #81, Closes #80

## テスト

- [x] `swift build` が通ることを確認した
- [x] `swift test` が通ることを確認した（141件全パス）
- [x] 手動動作確認済み

## チェックリスト

- [x] コミットメッセージが規則に従っている
- [ ] `release/**` → `main` の PR の場合、開発用ファイル（`.claude/`, `CLAUDE.md`）を削除している