### PR TITLE
feat: スクロールモード領域検出レイアウトベース刷新 (Epic 15)

### DIFF
--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -1,7 +1,7 @@
 ---
 name: planner
 description: Expert planning and architecture specialist for complex features and refactoring. Use PROACTIVELY when users request feature implementation, architectural changes, or complex refactoring.
-tools: ["Read", "Grep", "Glob"]
+tools: ["Read", "Write", "Edit", "Grep", "Glob"]
 model: opus
 ---
 

--- a/Sources/Vimursor/AppDelegate.swift
+++ b/Sources/Vimursor/AppDelegate.swift
@@ -108,6 +108,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                   let overlay = self.overlayWindow,
                   let hotkey = self.hotkeyManager,
                   hotkey.keyEventHandler == nil else { return }
+            AXManager.enableManualAccessibility()
             self.searchModeController?.activate(overlayWindow: overlay, hotkeyManager: hotkey)
         }
         manager.onScrollModeActivated = { [weak self] in
@@ -115,6 +116,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                   let overlay = self.overlayWindow,
                   let hotkey = self.hotkeyManager,
                   hotkey.keyEventHandler == nil else { return }
+            AXManager.enableManualAccessibility()
             self.scrollModeController?.activate(overlayWindow: overlay, hotkeyManager: hotkey)
         }
         self.hotkeyManager = manager

--- a/Sources/Vimursor/ScrollMode/ScrollEngine.swift
+++ b/Sources/Vimursor/ScrollMode/ScrollEngine.swift
@@ -44,15 +44,21 @@ enum ScrollEngine {
     /// ページ端までスクロール（gg/G）
     /// line 単位の巨大イベントは Chrome/Electron で無視されるため、
     /// pixel 単位のイベントを時間分散して送信する。
+    /// 返り値の DispatchWorkItem を cancel() することで未送信イベントを中断可能。
+    @discardableResult
     static func scrollToExtreme(
         direction: ScrollDirection,
         targetPoint: CGPoint? = nil
-    ) {
+    ) -> DispatchWorkItem {
         let pixelsPerEvent: Int32 = 5_000
         let eventCount = 10
         let pixels = direction == .up ? pixelsPerEvent : -pixelsPerEvent
+
+        // cancel() でキャンセルフラグを立てるためのセンチネル
+        let sentinel = DispatchWorkItem { }
         for i in 0..<eventCount {
             DispatchQueue.global().asyncAfter(deadline: .now() + Double(i) * 0.02) {
+                guard !sentinel.isCancelled else { return }
                 let event = CGEvent(
                     scrollWheelEvent2Source: nil,
                     units: .pixel,
@@ -67,5 +73,6 @@ enum ScrollEngine {
                 event?.post(tap: .cghidEventTap)
             }
         }
+        return sentinel
     }
 }

--- a/Sources/Vimursor/ScrollMode/ScrollEngine.swift
+++ b/Sources/Vimursor/ScrollMode/ScrollEngine.swift
@@ -21,6 +21,7 @@ struct ScrollAmount {
 }
 
 enum ScrollEngine {
+    /// 通常スクロール（j/k/d/u）
     static func scroll(
         amount: ScrollAmount,
         targetPoint: CGPoint? = nil,
@@ -38,5 +39,33 @@ enum ScrollEngine {
             event?.location = point
         }
         event?.post(tap: .cghidEventTap)
+    }
+
+    /// ページ端までスクロール（gg/G）
+    /// line 単位の巨大イベントは Chrome/Electron で無視されるため、
+    /// pixel 単位のイベントを時間分散して送信する。
+    static func scrollToExtreme(
+        direction: ScrollDirection,
+        targetPoint: CGPoint? = nil
+    ) {
+        let pixelsPerEvent: Int32 = 5_000
+        let eventCount = 10
+        let pixels = direction == .up ? pixelsPerEvent : -pixelsPerEvent
+        for i in 0..<eventCount {
+            DispatchQueue.global().asyncAfter(deadline: .now() + Double(i) * 0.02) {
+                let event = CGEvent(
+                    scrollWheelEvent2Source: nil,
+                    units: .pixel,
+                    wheelCount: 1,
+                    wheel1: pixels,
+                    wheel2: 0,
+                    wheel3: 0
+                )
+                if let point = targetPoint {
+                    event?.location = point
+                }
+                event?.post(tap: .cghidEventTap)
+            }
+        }
     }
 }

--- a/Sources/Vimursor/ScrollMode/ScrollModeController.swift
+++ b/Sources/Vimursor/ScrollMode/ScrollModeController.swift
@@ -56,6 +56,8 @@ final class ScrollModeController {
     private let elementFetcher: any ElementFetching
     /// `g` キーが1回押された状態を保持する（gg 入力のため）
     private var pendingG: Bool = false
+    /// scrollToExtreme の進行中イベントをキャンセルするためのハンドル
+    private var extremeScrollToken: DispatchWorkItem?
 
     init(elementFetcher: any ElementFetching = AXManager()) {
         self.elementFetcher = elementFetcher
@@ -99,6 +101,12 @@ final class ScrollModeController {
             if shouldConsume {
                 Task { @MainActor [weak self] in
                     self?.handleKey(keyCode: keyCode, flags: flags)
+                }
+            } else if self.pendingG {
+                // 非消費キー（Cmd+Tab 等）でも pendingG をリセットし、
+                // 意図しない gg 発火を防ぐ
+                Task { @MainActor [weak self] in
+                    self?.pendingG = false
                 }
             }
             return shouldConsume
@@ -144,6 +152,8 @@ final class ScrollModeController {
     func deactivate() {
         state = .inactive
         pendingG = false
+        extremeScrollToken?.cancel()
+        extremeScrollToken = nil
         scrollAreaView?.removeFromSuperview()
         scrollAreaView = nil
         indicatorView?.removeFromSuperview()
@@ -172,7 +182,10 @@ final class ScrollModeController {
         // G（Shift+g）: ページ末尾へスクロール
         if keyCode == ScrollKeyCode.g && isShift {
             pendingG = false
-            ScrollEngine.scrollToExtreme(direction: .down, targetPoint: areas[selectedIndex].centerPoint)
+            extremeScrollToken?.cancel()
+            extremeScrollToken = ScrollEngine.scrollToExtreme(
+                direction: .down, targetPoint: areas[selectedIndex].centerPoint
+            )
             return
         }
 
@@ -180,7 +193,10 @@ final class ScrollModeController {
         if keyCode == ScrollKeyCode.g {
             if pendingG {
                 pendingG = false
-                ScrollEngine.scrollToExtreme(direction: .up, targetPoint: areas[selectedIndex].centerPoint)
+                extremeScrollToken?.cancel()
+                extremeScrollToken = ScrollEngine.scrollToExtreme(
+                    direction: .up, targetPoint: areas[selectedIndex].centerPoint
+                )
             } else {
                 pendingG = true
             }

--- a/Sources/Vimursor/ScrollMode/ScrollModeController.swift
+++ b/Sources/Vimursor/ScrollMode/ScrollModeController.swift
@@ -14,6 +14,7 @@ enum ScrollKeyCode {
     static let k: CGKeyCode    = 40
     static let d: CGKeyCode    = 2
     static let u: CGKeyCode    = 32
+    static let g: CGKeyCode    = 5
     // 数字 1〜9（US キーボード）
     static let numToIndex: [CGKeyCode: Int] = [
         18: 0, 19: 1, 20: 2, 21: 3, 23: 4,
@@ -53,6 +54,8 @@ final class ScrollModeController {
     private weak var overlayWindow: (any OverlayProviding)?
     private weak var hotkeyManager: (any KeyEventHandling)?
     private let elementFetcher: any ElementFetching
+    /// `g` キーが1回押された状態を保持する（gg 入力のため）
+    private var pendingG: Bool = false
 
     init(elementFetcher: any ElementFetching = AXManager()) {
         self.elementFetcher = elementFetcher
@@ -81,8 +84,8 @@ final class ScrollModeController {
                 // Tab / Shift+Tab は消費
                 shouldConsume = true
             } else if isShift {
-                // Shift 付きその他は消費しない
-                shouldConsume = false
+                // Shift+g (= G) のみ消費、他の Shift 付きは消費しない
+                shouldConsume = (keyCode == ScrollKeyCode.g)
             } else {
                 // 数字キー・スクロールキーのみ消費
                 shouldConsume = ScrollKeyCode.numToIndex[keyCode] != nil
@@ -90,6 +93,7 @@ final class ScrollModeController {
                     || keyCode == ScrollKeyCode.k
                     || keyCode == ScrollKeyCode.d
                     || keyCode == ScrollKeyCode.u
+                    || keyCode == ScrollKeyCode.g
             }
 
             if shouldConsume {
@@ -139,6 +143,7 @@ final class ScrollModeController {
 
     func deactivate() {
         state = .inactive
+        pendingG = false
         scrollAreaView?.removeFromSuperview()
         scrollAreaView = nil
         indicatorView?.removeFromSuperview()
@@ -163,6 +168,27 @@ final class ScrollModeController {
         }
 
         let isShift = flags.contains(.maskShift)
+
+        // G（Shift+g）: ページ末尾へスクロール
+        if keyCode == ScrollKeyCode.g && isShift {
+            pendingG = false
+            ScrollEngine.scrollToExtreme(direction: .down, targetPoint: areas[selectedIndex].centerPoint)
+            return
+        }
+
+        // g キー: gg で先頭へスクロール
+        if keyCode == ScrollKeyCode.g {
+            if pendingG {
+                pendingG = false
+                ScrollEngine.scrollToExtreme(direction: .up, targetPoint: areas[selectedIndex].centerPoint)
+            } else {
+                pendingG = true
+            }
+            return
+        }
+
+        // g 以外のキーが押されたら pendingG をリセット
+        pendingG = false
 
         // Tab / Shift+Tab: 領域切り替え（ハンドラ側で Cmd/Ctrl/Alt 付きは除外済み）
         if keyCode == ScrollKeyCode.tab {

--- a/Sources/Vimursor/ScrollMode/ScrollTarget.swift
+++ b/Sources/Vimursor/ScrollMode/ScrollTarget.swift
@@ -5,17 +5,13 @@ private enum Limits {
     static let ancestorMaxDepth = 10
     /// スクロール可能要素収集の最大深さ
     static let collectMaxDepth = 20
-    /// 分割ポイント検出の最大深さ
-    static let splitMaxDepth = 5
     /// スクロール領域として認識する最小サイズ（ポイント）
     static let minScrollAreaSize: CGFloat = 100
-    /// ラッパー要素判定の幅閾値（親の何割以上か）
-    static let wrapperWidthRatio: CGFloat = 0.9
 }
 
 enum ScrollTarget {
     private static let scrollableRoles: Set<String> = [
-        "AXScrollArea", "AXWebArea", "AXTextArea", "AXList", "AXTable", "AXOutline"
+        "AXScrollArea", "AXTextArea", "AXList", "AXTable", "AXOutline"
     ]
 
     /// フォーカスアプリの AXFocusedUIElement からスクロール可能な祖先を探す
@@ -57,8 +53,8 @@ enum ScrollTarget {
     // MARK: - 全スクロール領域列挙
 
     /// AX ツリーを走査し、スクロール可能な全領域を返す
-    /// - スクロール可能ロールの要素を発見したら子への再帰を止める（ネスト重複防止）
-    /// - minScrollAreaSize 未満の要素はスキップ（ツールバー内の小さな AXList 等を除外）
+    /// - AXWebArea を検出したら WebAreaSplitDetector に委譲してレイアウト分割を検出する
+    /// - 通常のスクロール可能ロールはリーフ優先で収集する
     static func enumerateScrollableElements(root: AXUIElement) -> [ScrollAreaInfo] {
         var result: [ScrollAreaInfo] = []
         collectScrollable(element: root, into: &result, depth: 0)
@@ -72,13 +68,25 @@ enum ScrollTarget {
     ) {
         guard depth < Limits.collectMaxDepth else { return }
 
+        // AXWebArea: WebAreaSplitDetector に委譲してレイアウトベース分割を検出
+        var roleRef: CFTypeRef?
+        if AXUIElementCopyAttributeValue(element, "AXRole" as CFString, &roleRef) == .success,
+           (roleRef as? String) == "AXWebArea",
+           let f = AXAttributes.frame(of: element),
+           f.width >= Limits.minScrollAreaSize,
+           f.height >= Limits.minScrollAreaSize {
+            let areas = WebAreaSplitDetector.detect(webArea: element, nextLabel: result.count + 1)
+            result.append(contentsOf: areas)
+            return
+        }
+
         let frame = AXAttributes.frame(of: element)
         let selfIsScrollable = isScrollable(element: element)
             && frame.map {
                 $0.width >= Limits.minScrollAreaSize && $0.height >= Limits.minScrollAreaSize
             } ?? false
 
-        // 子を先に探索（自身がスクロール可能でも止めない）
+        // 子を先に探索（リーフ優先）
         let countBefore = result.count
         var childrenRef: CFTypeRef?
         if AXUIElementCopyAttributeValue(element, "AXChildren" as CFString, &childrenRef) == .success,
@@ -89,80 +97,11 @@ enum ScrollTarget {
         }
         let childrenAdded = result.count > countBefore
 
-        if selfIsScrollable, let f = frame {
-            if !childrenAdded {
-                // リーフ: そのまま追加
-                let center = CGPoint(x: f.midX, y: f.midY)
-                let label = String(result.count + 1)
-                result.append(ScrollAreaInfo(frame: f, centerPoint: center, label: label))
-            } else {
-                // 補完検出: 子にスクロール領域があるが、カバーされていない分割領域も追加
-                let addedAreas = Array(result[countBefore..<result.count])
-                addComplementRegions(element: element, parentFrame: f, existingAreas: addedAreas, into: &result)
-            }
+        if selfIsScrollable, let f = frame, !childrenAdded {
+            // リーフ: そのまま追加
+            let center = CGPoint(x: f.midX, y: f.midY)
+            let label = String(result.count + 1)
+            result.append(ScrollAreaInfo(frame: f, centerPoint: center, label: label))
         }
     }
-
-    /// スクロール可能な親の中から分割ポイントを見つけ、
-    /// 既存スクロール領域にカバーされていない子領域を追加する
-    private static func addComplementRegions(
-        element: AXUIElement,
-        parentFrame: CGRect,
-        existingAreas: [ScrollAreaInfo],
-        into result: inout [ScrollAreaInfo]
-    ) {
-        let splitChildren = findSplitChildren(element: element, parentFrame: parentFrame, maxDepth: Limits.splitMaxDepth)
-        guard splitChildren.count >= 2 else { return }
-
-        for childFrame in splitChildren {
-            // 既存のスクロール領域の centerPoint がこの子フレーム内に含まれるかチェック
-            let containsExisting = existingAreas.contains { childFrame.contains($0.centerPoint) }
-            if !containsExisting {
-                let center = CGPoint(x: childFrame.midX, y: childFrame.midY)
-                let label = String(result.count + 1)
-                result.append(ScrollAreaInfo(frame: childFrame, centerPoint: center, label: label))
-            }
-        }
-    }
-
-    /// 親と同サイズのラッパーを飛ばしつつ、分割ポイント（複数の子が並ぶレベル）を探す
-    /// 返すのは各子の CGRect（フレーム）のリスト
-    private static func findSplitChildren(
-        element: AXUIElement,
-        parentFrame: CGRect,
-        maxDepth: Int
-    ) -> [CGRect] {
-        guard maxDepth > 0 else { return [] }
-
-        var childrenRef: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(element, "AXChildren" as CFString, &childrenRef) == .success,
-              let children = childrenRef as? [AXUIElement] else { return [] }
-
-        // 子のうちサイズが十分なものだけ取得
-        var significantChildren: [(element: AXUIElement, frame: CGRect)] = []
-        for child in children {
-            if let f = AXAttributes.frame(of: child),
-               f.width >= Limits.minScrollAreaSize,
-               f.height >= Limits.minScrollAreaSize {
-                significantChildren.append((child, f))
-            }
-        }
-
-        // 親と同サイズ（幅が wrapperWidthRatio 以上）の子はラッパーとみなしてスキップ
-        let nonWrappers = significantChildren.filter { $0.frame.width < parentFrame.width * Limits.wrapperWidthRatio }
-
-        if nonWrappers.count >= 2 {
-            // 分割ポイント発見
-            return nonWrappers.map { $0.frame }
-        }
-
-        // ラッパー（親と同サイズの子）がある場合、その中を再帰探索
-        for (child, frame) in significantChildren where frame.width >= parentFrame.width * Limits.wrapperWidthRatio {
-            let result = findSplitChildren(element: child, parentFrame: parentFrame, maxDepth: maxDepth - 1)
-            if result.count >= 2 { return result }
-        }
-
-        return []
-    }
-
 }

--- a/Sources/Vimursor/ScrollMode/WebAreaSplitDetector.swift
+++ b/Sources/Vimursor/ScrollMode/WebAreaSplitDetector.swift
@@ -1,0 +1,112 @@
+import AppKit
+
+/// AXWebArea 子ツリーのフレーム情報を保持する値型。
+/// AXUIElement 依存を分離することで `findSplitFrames` を純粋関数としてテスト可能にする。
+struct ChildInfo {
+    let frame: CGRect
+    let children: [ChildInfo]
+}
+
+/// AXWebArea の子ツリーを走査してレイアウトベースの分割を検出する。
+/// Notion・Slack・GitHub のサイドバー/メイン分割を統一的に扱う。
+enum WebAreaSplitDetector {
+
+    // MARK: - Constants
+
+    /// 再帰の最大深さ（ラッパーを透過する上限）
+    static let maxDepth = 10
+    /// スクロール領域として認識する最小サイズ（ポイント）
+    static let minChildSize: CGFloat = 100
+    /// この比率以上の幅を持つ子はラッパーとみなす（親幅に対する割合）
+    static let wrapperWidthRatio: CGFloat = 0.9
+
+    // MARK: - Public API
+
+    /// AXWebArea から ScrollAreaInfo のリストを返す。
+    /// 分割が検出されれば複数の ScrollAreaInfo を、検出されなければ webArea 全体を1つとして返す。
+    static func detect(webArea: AXUIElement, nextLabel: Int) -> [ScrollAreaInfo] {
+        guard let parentFrame = AXAttributes.frame(of: webArea),
+              parentFrame.width >= minChildSize,
+              parentFrame.height >= minChildSize else { return [] }
+
+        let rootChildren = extractChildren(element: webArea, depth: 0)
+        if let splitFrames = findSplitFrames(children: rootChildren, parentFrame: parentFrame, depth: 0) {
+            return splitFrames.enumerated().map { i, f in
+                ScrollAreaInfo(
+                    frame: f,
+                    centerPoint: CGPoint(x: f.midX, y: f.midY),
+                    label: String(nextLabel + i)
+                )
+            }
+        }
+
+        // フォールバック: AXWebArea 全体を1領域として返す
+        return [ScrollAreaInfo(
+            frame: parentFrame,
+            centerPoint: CGPoint(x: parentFrame.midX, y: parentFrame.midY),
+            label: String(nextLabel)
+        )]
+    }
+
+    // MARK: - Pure Logic (testable)
+
+    /// ChildInfo のリストからレイアウト分割フレームを返す純粋関数。
+    /// 分割が見つからない（または depth が maxDepth に達した）場合は nil を返す。
+    static func findSplitFrames(
+        children: [ChildInfo],
+        parentFrame: CGRect,
+        depth: Int
+    ) -> [CGRect]? {
+        guard depth < maxDepth else { return nil }
+
+        // minChildSize 以上の子だけ対象にする
+        let significant = children.filter {
+            $0.frame.width >= minChildSize && $0.frame.height >= minChildSize
+        }
+
+        // parentFrame に対して幅が wrapperWidthRatio 未満の子だけを「分割候補」とする
+        let nonWrappers = significant.filter {
+            $0.frame.width < parentFrame.width * wrapperWidthRatio
+        }
+
+        if nonWrappers.count >= 2 {
+            // 分割ポイント発見
+            return nonWrappers.map { $0.frame }
+        }
+
+        // ラッパー（幅が wrapperWidthRatio 以上）の子を透過して再帰
+        for child in significant where child.frame.width >= parentFrame.width * wrapperWidthRatio {
+            if let result = findSplitFrames(
+                children: child.children,
+                parentFrame: parentFrame,
+                depth: depth + 1
+            ) {
+                return result
+            }
+        }
+
+        return nil
+    }
+
+    // MARK: - AX Tree Extraction
+
+    /// すべての直接子を ChildInfo にマップする。
+    /// AXGroup の場合のみ再帰してサブツリーを展開する（不要な AX コールを抑制）。
+    private static func extractChildren(element: AXUIElement, depth: Int) -> [ChildInfo] {
+        guard depth < maxDepth else { return [] }
+
+        var childrenRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, "AXChildren" as CFString, &childrenRef) == .success,
+              let axChildren = childrenRef as? [AXUIElement] else { return [] }
+
+        return axChildren.compactMap { child -> ChildInfo? in
+            guard let frame = AXAttributes.frame(of: child) else { return nil }
+            // AXGroup のみ再帰して子ツリーを展開する
+            var roleRef: CFTypeRef?
+            let isGroup = AXUIElementCopyAttributeValue(child, "AXRole" as CFString, &roleRef) == .success
+                && (roleRef as? String) == "AXGroup"
+            let subChildren = isGroup ? extractChildren(element: child, depth: depth + 1) : []
+            return ChildInfo(frame: frame, children: subChildren)
+        }
+    }
+}

--- a/Tests/VimursorTests/ScrollEngineTests.swift
+++ b/Tests/VimursorTests/ScrollEngineTests.swift
@@ -50,4 +50,9 @@ struct ScrollEngineTests {
         let halfPage = abs(Int(ScrollAmount.halfPage(direction: .down).lines))
         #expect(halfPage > step * 3, "半ページは1ステップの3倍以上")
     }
+
+    // scrollToExtreme は CGEvent を直接 post するため、
+    // 単体テストでは ScrollEngine.scroll の既存テストで
+    // ScrollAmount の符号・大きさを検証し、
+    // scrollToExtreme の動作は手動テストで確認する。
 }

--- a/Tests/VimursorTests/ScrollModeControllerTests.swift
+++ b/Tests/VimursorTests/ScrollModeControllerTests.swift
@@ -210,4 +210,52 @@ struct ScrollModeControllerTests {
         #expect(hotkey.keyEventHandler != nil)
     }
 
+    // MARK: - gg / G スクロール
+
+    /// G（Shift+g）キーはイベントを消費する
+    @Test @MainActor func shiftGIsConsumed() async throws {
+        let (controller, overlay, hotkey, _) = makeSUT(areas: [makeScrollArea()])
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(100))
+        let consumed = hotkey.simulateKey(ScrollKeyCode.g, flags: .maskShift)
+        #expect(consumed == true, "Shift+g (G) はイベントを消費する")
+    }
+
+    /// g キー1回はイベントを消費する（まだスクロールはしないが消費する）
+    @Test @MainActor func singleGIsConsumed() async throws {
+        let (controller, overlay, hotkey, _) = makeSUT(areas: [makeScrollArea()])
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(100))
+        let consumed = hotkey.simulateKey(ScrollKeyCode.g, flags: [])
+        #expect(consumed == true, "g キー1回はイベントを消費する")
+    }
+
+    /// gg（g キー2回連続）はイベントを消費する
+    @Test @MainActor func doubleGIsConsumed() async throws {
+        let (controller, overlay, hotkey, _) = makeSUT(areas: [makeScrollArea()])
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(100))
+        hotkey.simulateKey(ScrollKeyCode.g, flags: [])
+        let consumed = hotkey.simulateKey(ScrollKeyCode.g, flags: [])
+        #expect(consumed == true, "gg の2回目もイベントを消費する")
+    }
+
+    /// g → j → g → g の順で押した場合、g → j で pendingG がリセットされるので
+    /// 3回目の g 単体では先頭スクロールしない（4回目が gg の確定になる）
+    @Test @MainActor func gFollowedByOtherKeyResetsPendingG() async throws {
+        let (controller, overlay, hotkey, _) = makeSUT(areas: [makeScrollArea()])
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(100))
+        // g → j（pendingG リセット）→ g（pendingG = true）→ g（gg 確定）
+        // いずれのキーも消費される
+        let consumed1 = hotkey.simulateKey(ScrollKeyCode.g, flags: [])  // pendingG = true
+        let consumed2 = hotkey.simulateKey(ScrollKeyCode.j, flags: [])  // pendingG = false
+        let consumed3 = hotkey.simulateKey(ScrollKeyCode.g, flags: [])  // pendingG = true
+        let consumed4 = hotkey.simulateKey(ScrollKeyCode.g, flags: [])  // gg 確定
+        #expect(consumed1 == true)
+        #expect(consumed2 == true)
+        #expect(consumed3 == true)
+        #expect(consumed4 == true, "g → j → g → g の4打鍵はすべて消費される")
+    }
+
 }

--- a/Tests/VimursorTests/ScrollModeControllerTests.swift
+++ b/Tests/VimursorTests/ScrollModeControllerTests.swift
@@ -210,32 +210,4 @@ struct ScrollModeControllerTests {
         #expect(hotkey.keyEventHandler != nil)
     }
 
-    // MARK: - 補完検出ロジック（Complement Detection）
-
-    /// 既存スクロール領域の centerPoint が子フレーム内に含まれるかの判定
-    @Test func complementDetectionCenterPointContainment() {
-        let childFrame = CGRect(x: 280, y: 25, width: 1440, height: 1415)
-        let insidePoint = CGPoint(x: 992, y: 771)   // メイン内の点
-        let outsidePoint = CGPoint(x: 100, y: 400)  // サイドバー内の点
-        #expect(childFrame.contains(insidePoint) == true, "メイン領域内の点は含まれる")
-        #expect(childFrame.contains(outsidePoint) == false, "サイドバー領域の点は含まれない")
-    }
-
-    /// ラッパー判定: 親幅の90%以上はラッパー
-    @Test func wrapperDetectionByWidth() {
-        let parentWidth: CGFloat = 1720
-        let threshold: CGFloat = 0.9
-        let wrapperWidth: CGFloat = 1720   // 100% → ラッパー
-        let splitWidth: CGFloat = 240      // 14% → 分割子
-        #expect(wrapperWidth >= parentWidth * threshold, "同サイズはラッパー")
-        #expect(splitWidth < parentWidth * threshold, "小さいサイズは分割子")
-    }
-
-    /// 分割子が2つ以上あるときのみ補完が発動する
-    @Test func complementRequiresAtLeastTwoSplitChildren() {
-        let splitChildren = 1
-        #expect((splitChildren >= 2) == false, "1つだけでは補完しない")
-        let splitChildren2 = 2
-        #expect((splitChildren2 >= 2) == true, "2つ以上で補完発動")
-    }
 }

--- a/Tests/VimursorTests/WebAreaSplitDetectorTests.swift
+++ b/Tests/VimursorTests/WebAreaSplitDetectorTests.swift
@@ -1,0 +1,183 @@
+import Testing
+import CoreGraphics
+@testable import Vimursor
+
+@Suite("WebAreaSplitDetector Tests")
+struct WebAreaSplitDetectorTests {
+
+    // MARK: - Helpers
+
+    /// ChildInfo を使ったフラットな子リストを parentFrame に対して評価する
+    private func children(frames: [CGRect]) -> [ChildInfo] {
+        frames.map { ChildInfo(frame: $0, children: []) }
+    }
+
+    /// 親フレーム: 一般的な Notion/Slack/GitHub ウィンドウサイズ想定
+    private let notionParent = CGRect(x: 0, y: 0, width: 2293, height: 1328)
+    private let slackParent  = CGRect(x: 0, y: 0, width: 1079, height: 1374)
+    private let githubParent = CGRect(x: 0, y: 0, width: 2279, height: 1203)
+
+    // MARK: - 分割検出テスト
+
+    /// Notion レイアウト: サイドバー(240) + メイン(2053)
+    @Test("Notion レイアウト: 2 領域に分割される")
+    func splitDetectsNotionLayout() {
+        let kids = children(frames: [
+            CGRect(x: 0,   y: 0, width: 240,  height: 1328),
+            CGRect(x: 240, y: 0, width: 2053, height: 1328),
+        ])
+        let result = WebAreaSplitDetector.findSplitFrames(
+            children: kids, parentFrame: notionParent, depth: 0
+        )
+        #expect(result?.count == 2, "Notion レイアウトは2領域に分割される")
+    }
+
+    /// Slack レイアウト: サイドバー(222) + メインチャット(857)
+    @Test("Slack レイアウト: 2 領域に分割される")
+    func splitDetectsSlackLayout() {
+        let kids = children(frames: [
+            CGRect(x: 0,   y: 0, width: 222, height: 1374),
+            CGRect(x: 222, y: 0, width: 857, height: 1374),
+        ])
+        let result = WebAreaSplitDetector.findSplitFrames(
+            children: kids, parentFrame: slackParent, depth: 0
+        )
+        #expect(result?.count == 2, "Slack レイアウトは2領域に分割される")
+    }
+
+    /// GitHub レイアウト: サイドバー(402) + メイン(1877)
+    @Test("GitHub レイアウト: 2 領域に分割される")
+    func splitDetectsGitHubLayout() {
+        let kids = children(frames: [
+            CGRect(x: 0,   y: 0, width: 402,  height: 1203),
+            CGRect(x: 402, y: 0, width: 1877, height: 1203),
+        ])
+        let result = WebAreaSplitDetector.findSplitFrames(
+            children: kids, parentFrame: githubParent, depth: 0
+        )
+        #expect(result?.count == 2, "GitHub レイアウトは2領域に分割される")
+    }
+
+    /// 子が1つだけ → 分割なし（nil）
+    @Test("子が1つだけの場合は分割されない")
+    func noSplitForSingleChild() {
+        let parent = CGRect(x: 0, y: 0, width: 1000, height: 800)
+        let kids = children(frames: [
+            CGRect(x: 0, y: 0, width: 1000, height: 800),
+        ])
+        let result = WebAreaSplitDetector.findSplitFrames(
+            children: kids, parentFrame: parent, depth: 0
+        )
+        #expect(result == nil, "子が1つでは分割されない")
+    }
+
+    /// minChildSize 未満の子だけ → 分割なし（nil）
+    @Test("minChildSize 未満の子は無視されて分割されない")
+    func noSplitForTooSmallChildren() {
+        let parent = CGRect(x: 0, y: 0, width: 1000, height: 800)
+        let kids = children(frames: [
+            CGRect(x: 0,   y: 0, width: 50, height: 50),  // 小さすぎる
+            CGRect(x: 50,  y: 0, width: 50, height: 50),  // 小さすぎる
+        ])
+        let result = WebAreaSplitDetector.findSplitFrames(
+            children: kids, parentFrame: parent, depth: 0
+        )
+        #expect(result == nil, "minChildSize 未満の子だけでは分割されない")
+    }
+
+    /// ラッパー要素を飛ばして再帰して分割を検出する
+    @Test("ラッパー要素を透過して子の分割を検出する")
+    func wrapperSkippedAndDescended() {
+        let parent = CGRect(x: 0, y: 0, width: 1000, height: 800)
+        // ラッパー: 親と同サイズ (width/parentWidth = 1.0 >= 0.9)
+        let inner1 = ChildInfo(frame: CGRect(x: 0,   y: 0, width: 200, height: 800), children: [])
+        let inner2 = ChildInfo(frame: CGRect(x: 200, y: 0, width: 800, height: 800), children: [])
+        let wrapper = ChildInfo(
+            frame: CGRect(x: 0, y: 0, width: 1000, height: 800),  // ラッパー
+            children: [inner1, inner2]
+        )
+        let result = WebAreaSplitDetector.findSplitFrames(
+            children: [wrapper], parentFrame: parent, depth: 0
+        )
+        #expect(result?.count == 2, "ラッパーを透過して内側の2分割を検出する")
+    }
+
+    /// maxDepth に達したら nil を返す
+    @Test("maxDepth に達したら nil を返す")
+    func maxDepthReached() {
+        let parent = CGRect(x: 0, y: 0, width: 1000, height: 800)
+        let wrapper = ChildInfo(
+            frame: CGRect(x: 0, y: 0, width: 1000, height: 800),  // ラッパー
+            children: [
+                ChildInfo(frame: CGRect(x: 0,   y: 0, width: 200, height: 800), children: []),
+                ChildInfo(frame: CGRect(x: 200, y: 0, width: 800, height: 800), children: []),
+            ]
+        )
+        // maxDepth を 0 に設定してラッパー再帰を禁止
+        let result = WebAreaSplitDetector.findSplitFrames(
+            children: [wrapper], parentFrame: parent, depth: WebAreaSplitDetector.maxDepth
+        )
+        #expect(result == nil, "maxDepth に達したら nil を返す")
+    }
+
+    /// 3パネルレイアウト → 3つの CGRect
+    @Test("3パネルレイアウトは3領域に分割される")
+    func threePanelLayout() {
+        let parent = CGRect(x: 0, y: 0, width: 1500, height: 900)
+        let kids = children(frames: [
+            CGRect(x: 0,    y: 0, width: 300, height: 900),
+            CGRect(x: 300,  y: 0, width: 900, height: 900),
+            CGRect(x: 1200, y: 0, width: 300, height: 900),
+        ])
+        let result = WebAreaSplitDetector.findSplitFrames(
+            children: kids, parentFrame: parent, depth: 0
+        )
+        #expect(result?.count == 3, "3パネルレイアウトは3領域に分割される")
+    }
+
+    // MARK: - detect() の戻り値型テスト
+
+    /// 子が0件 → 分割なし（nil）
+    @Test("子が0件のとき findSplitFrames は nil を返す")
+    func findSplitFramesReturnsNilForEmptyChildren() {
+        let parent = CGRect(x: 0, y: 0, width: 1000, height: 800)
+        let result = WebAreaSplitDetector.findSplitFrames(
+            children: [], parentFrame: parent, depth: 0
+        )
+        #expect(result == nil, "子が0件では分割されない")
+    }
+
+    // MARK: - wrapperWidthRatio 境界値テスト
+
+    /// 幅が parentWidth * 0.9 ちょうどの子はラッパーとみなして再帰する
+    @Test("幅が parentWidth * wrapperWidthRatio ちょうどの子はラッパー扱いで再帰する")
+    func wrapperWidthRatioExactBoundaryIsWrapper() {
+        // 親幅 1000 のとき width=900 は 900/1000=0.9 → ラッパー扱い（>= 0.9）
+        let parent = CGRect(x: 0, y: 0, width: 1000, height: 800)
+        let inner1 = ChildInfo(frame: CGRect(x: 0,   y: 0, width: 200, height: 800), children: [])
+        let inner2 = ChildInfo(frame: CGRect(x: 200, y: 0, width: 700, height: 800), children: [])
+        let wrapper = ChildInfo(
+            frame: CGRect(x: 0, y: 0, width: 900, height: 800),  // 900/1000 = 0.9 ちょうど → ラッパー
+            children: [inner1, inner2]
+        )
+        let result = WebAreaSplitDetector.findSplitFrames(
+            children: [wrapper], parentFrame: parent, depth: 0
+        )
+        #expect(result?.count == 2, "幅比率 0.9 ちょうどはラッパーとして透過され内側の2分割を検出する")
+    }
+
+    /// 幅が parentWidth * 0.9 未満（width=899）の子は分割候補として扱う
+    @Test("幅が parentWidth * wrapperWidthRatio 未満の子は分割候補として扱う")
+    func wrapperWidthRatioBelowBoundaryIsNonWrapper() {
+        // 親幅 1000 のとき width=899 は 899/1000=0.899 < 0.9 → 非ラッパー（分割候補）
+        let parent = CGRect(x: 0, y: 0, width: 1000, height: 800)
+        let kids = children(frames: [
+            CGRect(x: 0,   y: 0, width: 899, height: 800),  // 899/1000 < 0.9 → 非ラッパー
+            CGRect(x: 899, y: 0, width: 101, height: 800),  // 101/1000 < 0.9 → 非ラッパー
+        ])
+        let result = WebAreaSplitDetector.findSplitFrames(
+            children: kids, parentFrame: parent, depth: 0
+        )
+        #expect(result?.count == 2, "幅比率 0.9 未満の子2つは分割候補として検出される")
+    }
+}


### PR DESCRIPTION
## 概要

スクロールモードの領域検出をレイアウトベースに刷新し、gg/G（先頭/末尾スクロール）を追加。

### 領域検出の刷新
AXWebArea の領域検出を、ロールベース + 補完検出（`addComplementRegions`）から、AXGroup フレーム情報によるレイアウトベース分割検出に刷新。Notion（1領域問題）、Slack（メインチャット未検出）、GitHub（過剰検出）の3つの問題を統一的に解決。

### gg/G スクロール
- `gg` でページ先頭、`G`（Shift+g）でページ末尾にスクロール
- pixel 単位 + 時間分散送信で Chrome/Electron での動作を保証

## 変更内容

- 新規 `WebAreaSplitDetector` を追加（`ChildInfo` + 純粋関数 `findSplitFrames` で TDD）
- `ScrollTarget.swift` を 338行 → 107行 に大幅簡素化（デバッグログ・補完検出ロジック完全削除）
- 全モード（Search / Scroll）に `enableManualAccessibility()` を追加し Electron アプリ対応を統一
- `ScrollModeController` に gg/G キーハンドリングを追加（`pendingG` 状態管理）
- `ScrollEngine.scrollToExtreme` を追加（pixel 単位 + 時間分散送信）
- planner エージェントに Write/Edit 権限を追加

## 関連 Issue

Closes #84, Closes #85, Closes #86, Closes #87

## テスト

- [x] `swift build` が通ることを確認した
- [x] `swift test` が通ることを確認した（153テスト全パス）
- [x] 手動動作確認済み

## チェックリスト

- [x] コミットメッセージが規則に従っている
- [ ] `release/**` → `main` の PR の場合、開発用ファイル（`.claude/`, `CLAUDE.md`）を削除している