### PR TITLE
docs: README に Homebrew インストール手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,14 @@ Scroll any window using familiar Vim motions.
 
 ## Installation
 
-### Download from GitHub Releases (recommended)
+### Homebrew (recommended)
+
+```bash
+brew tap kodakoda-koda/vimursor
+brew install --cask vimursor
+```
+
+### Download from GitHub Releases
 
 1. Download the latest `Vimursor.dmg` from the [Releases page](https://github.com/kodakoda-koda/Vimursor/releases)
 2. Open the DMG and drag `Vimursor.app` to the `/Applications` folder


### PR DESCRIPTION
## Summary

README に Homebrew 経由のインストール手順を推奨として追加。

## Changes

- `brew tap kodakoda-koda/vimursor && brew install --cask vimursor` の手順を追加
- Homebrew を推奨インストール方法に変更

## Self-Review Checklist

- [x] I've reviewed my own diff