### PR TITLE
fix: ユニバーサルバイナリでビルド（ARM + Intel 対応）

### DIFF
--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -12,10 +12,10 @@ MACOS_DIR="${CONTENTS}/MacOS"
 RESOURCES_DIR="${CONTENTS}/Resources"
 INFO_PLIST_SRC="${REPO_ROOT}/Sources/Vimursor/Info.plist"
 
-echo "==> Building release binary..."
+echo "==> Building universal release binary..."
 cd "${REPO_ROOT}"
-swift build -c release
-BIN_PATH="$(swift build -c release --show-bin-path)"
+swift build -c release --arch arm64 --arch x86_64
+BIN_PATH="$(swift build -c release --arch arm64 --arch x86_64 --show-bin-path)"
 BINARY_SRC="${BIN_PATH}/${APP_NAME}"
 
 echo "==> Assembling ${APP_NAME}.app bundle..."


### PR DESCRIPTION
## Summary

build-app.sh を `--arch arm64 --arch x86_64` でビルドするように変更し、Intel Mac でも起動できるようにする。

## Changes

- `swift build -c release` → `swift build -c release --arch arm64 --arch x86_64`

## Self-Review Checklist

- [x] I've reviewed my own diff

## Test Plan

- マージ後に v1.0.1 タグで再リリースし、Intel Mac で起動確認