### PR TITLE
feat: ヒントモード修飾キー付きクリック

### DIFF
--- a/Sources/Vimursor/Accessibility/AXManager.swift
+++ b/Sources/Vimursor/Accessibility/AXManager.swift
@@ -88,13 +88,39 @@ final class AXManager: @unchecked Sendable {
         }
     }
 
-    func clickAt(frame: CGRect) {
+    func clickAt(frame: CGRect, modifier: ClickModifier) {
         let screenHeight = NSScreen.main?.frame.height ?? 0
         let point = AXManager.centerScreenPoint(from: frame, screenHeight: screenHeight)
-        let down = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown,
-                           mouseCursorPosition: point, mouseButton: .left)
-        let up   = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp,
-                           mouseCursorPosition: point, mouseButton: .left)
+
+        switch modifier {
+        case .leftClick:
+            postMouseClick(point: point, downType: .leftMouseDown, upType: .leftMouseUp, button: .left)
+        case .commandClick:
+            postMouseClick(point: point, downType: .leftMouseDown, upType: .leftMouseUp, button: .left, flags: .maskCommand)
+        case .controlClick:
+            postMouseClick(point: point, downType: .leftMouseDown, upType: .leftMouseUp, button: .left, flags: .maskControl)
+        case .optionClick:
+            postMouseClick(point: point, downType: .leftMouseDown, upType: .leftMouseUp, button: .left, flags: .maskAlternate)
+        case .rightClick:
+            postMouseClick(point: point, downType: .rightMouseDown, upType: .rightMouseUp, button: .right)
+        }
+    }
+
+    private func postMouseClick(
+        point: CGPoint,
+        downType: CGEventType,
+        upType: CGEventType,
+        button: CGMouseButton,
+        flags: CGEventFlags = []
+    ) {
+        let down = CGEvent(mouseEventSource: nil, mouseType: downType,
+                           mouseCursorPosition: point, mouseButton: button)
+        let up = CGEvent(mouseEventSource: nil, mouseType: upType,
+                         mouseCursorPosition: point, mouseButton: button)
+        if !flags.isEmpty {
+            down?.flags = flags
+            up?.flags = flags
+        }
         down?.post(tap: .cghidEventTap)
         up?.post(tap: .cghidEventTap)
     }

--- a/Sources/Vimursor/Accessibility/AXManager.swift
+++ b/Sources/Vimursor/Accessibility/AXManager.swift
@@ -118,8 +118,8 @@ final class AXManager: @unchecked Sendable {
         let up = CGEvent(mouseEventSource: nil, mouseType: upType,
                          mouseCursorPosition: point, mouseButton: button)
         if !flags.isEmpty {
-            down?.flags = flags
-            up?.flags = flags
+            down?.flags.formUnion(flags)
+            up?.flags.formUnion(flags)
         }
         down?.post(tap: .cghidEventTap)
         up?.post(tap: .cghidEventTap)

--- a/Sources/Vimursor/HintMode/HintModeController.swift
+++ b/Sources/Vimursor/HintMode/HintModeController.swift
@@ -108,8 +108,8 @@ final class HintModeController {
             return
         }
 
-        // 修飾キー付きは無視（Cmd+Tab等）
-        guard flags.isDisjoint(with: [.maskCommand, .maskControl, .maskAlternate]) else { return }
+        // 修飾キーから ClickModifier を決定（Shift→右クリック, Cmd→Cmd+クリック等）
+        let clickModifier = ClickModifier.from(flags: flags)
 
         guard let char = KeyCodeMapping.charFromKeyCode(keyCode) else { return }
 
@@ -122,7 +122,7 @@ final class HintModeController {
         }
 
         if let exact = matches.first(where: { $0.label == newInput }) {
-            performClick(frame: exact.frame)
+            performClick(frame: exact.frame, modifier: clickModifier)
             return
         }
 
@@ -130,15 +130,15 @@ final class HintModeController {
         hintView?.update(hints: hints, inputPrefix: newInput)
     }
 
-    private func performClick(frame: CGRect) {
+    private func performClick(frame: CGRect, modifier: ClickModifier) {
         if settings.isContinuousMode {
-            performContinuousClick(frame: frame)
+            performContinuousClick(frame: frame, modifier: modifier)
         } else {
-            performSingleClick(frame: frame)
+            performSingleClick(frame: frame, modifier: modifier)
         }
     }
 
-    private func performContinuousClick(frame: CGRect) {
+    private func performContinuousClick(frame: CGRect, modifier: ClickModifier) {
         enterRestartingState()
         Task { @MainActor [weak self] in
             do {
@@ -148,12 +148,12 @@ final class HintModeController {
             }
             guard let self else { return }
             guard case .restarting = self.state else { return }  // ESCでdeactivateされていたら中断
-            self.elementFetcher.clickAt(frame: frame)
+            self.elementFetcher.clickAt(frame: frame, modifier: modifier)
             self.scheduleReactivation()
         }
     }
 
-    private func performSingleClick(frame: CGRect) {
+    private func performSingleClick(frame: CGRect, modifier: ClickModifier) {
         // 単発モード: オーバーレイ非表示後にクリック送信
         deactivate()
         Task { @MainActor [weak self] in
@@ -162,7 +162,7 @@ final class HintModeController {
             } catch is CancellationError {
                 return
             }
-            self?.elementFetcher.clickAt(frame: frame)
+            self?.elementFetcher.clickAt(frame: frame, modifier: modifier)
         }
     }
 

--- a/Sources/Vimursor/Protocols/ElementFetching.swift
+++ b/Sources/Vimursor/Protocols/ElementFetching.swift
@@ -5,5 +5,11 @@ protocol ElementFetching: AnyObject {
     @MainActor func buildUIElementInfos(elements: [AXElement], labels: [String]) -> [UIElementInfo]
     func fetchSearchableElements(in app: AXUIElement, completion: @escaping @Sendable ([SearchElementInfo]) -> Void)
     func fetchScrollableElements(in app: AXUIElement, completion: @escaping @Sendable ([ScrollAreaInfo]) -> Void)
-    func clickAt(frame: CGRect)
+    func clickAt(frame: CGRect, modifier: ClickModifier)
+}
+
+extension ElementFetching {
+    func clickAt(frame: CGRect) {
+        clickAt(frame: frame, modifier: .leftClick)
+    }
 }

--- a/Sources/Vimursor/Settings/AppSettings.swift
+++ b/Sources/Vimursor/Settings/AppSettings.swift
@@ -32,7 +32,7 @@ final class AppSettings: @unchecked Sendable {
         static let labelBackgroundOpacity: CGFloat = 0.95
         static let searchBarOpacity: CGFloat = 1.0
         static let hintCharacterSet: String = "fjrieodkslapnvmc"
-        static let isContinuousMode: Bool = true
+        static let isContinuousMode: Bool = false
         static let reactivationDelay: TimeInterval = 0.3
         static let scrollStepLines: Int = 3
     }

--- a/Sources/Vimursor/Shared/ClickModifier.swift
+++ b/Sources/Vimursor/Shared/ClickModifier.swift
@@ -1,0 +1,20 @@
+import CoreGraphics
+
+/// 修飾キーからクリックアクションへのマッピング
+enum ClickModifier: Sendable {
+    case leftClick      // 修飾キーなし → 通常の左クリック
+    case commandClick   // Cmd → Cmd+左クリック
+    case rightClick     // Shift → 右クリック（contextual menu）
+    case controlClick   // Ctrl → Ctrl+左クリック
+    case optionClick    // Option → Option+左クリック
+
+    /// CGEventFlags から ClickModifier を決定する。
+    /// 複数修飾キーが同時に押された場合の優先順位: Cmd > Ctrl > Option > Shift
+    static func from(flags: CGEventFlags) -> ClickModifier {
+        if flags.contains(.maskCommand)   { return .commandClick }
+        if flags.contains(.maskControl)   { return .controlClick }
+        if flags.contains(.maskAlternate) { return .optionClick }
+        if flags.contains(.maskShift)     { return .rightClick }
+        return .leftClick
+    }
+}

--- a/Sources/Vimursor/Shared/ClickModifier.swift
+++ b/Sources/Vimursor/Shared/ClickModifier.swift
@@ -11,10 +11,10 @@ enum ClickModifier: Sendable {
     /// CGEventFlags から ClickModifier を決定する。
     /// 複数修飾キーが同時に押された場合の優先順位: Cmd > Ctrl > Option > Shift
     static func from(flags: CGEventFlags) -> ClickModifier {
-        if flags.contains(.maskCommand)   { return .commandClick }
-        if flags.contains(.maskControl)   { return .controlClick }
+        if flags.contains(.maskCommand) { return .commandClick }
+        if flags.contains(.maskControl) { return .controlClick }
         if flags.contains(.maskAlternate) { return .optionClick }
-        if flags.contains(.maskShift)     { return .rightClick }
+        if flags.contains(.maskShift) { return .rightClick }
         return .leftClick
     }
 }

--- a/Tests/VimursorTests/AppSettingsTests.swift
+++ b/Tests/VimursorTests/AppSettingsTests.swift
@@ -40,10 +40,10 @@ struct AppSettingsTests {
         #expect(settings.hintCharacterSet == "fjrieodkslapnvmc")
     }
 
-    @Test("isContinuousMode のデフォルト値は true")
+    @Test("isContinuousMode のデフォルト値は false")
     func defaultIsContinuousMode() {
         let settings = makeSettings()
-        #expect(settings.isContinuousMode == true)
+        #expect(settings.isContinuousMode == false)
     }
 
     @Test("reactivationDelay のデフォルト値は 0.3")
@@ -173,10 +173,10 @@ struct AppSettingsTests {
     @Test("toggleContinuousMode() で isContinuousMode が反転すること")
     func toggleContinuousMode() {
         let settings = makeSettings()
-        #expect(settings.isContinuousMode == true)
-        settings.toggleContinuousMode()
         #expect(settings.isContinuousMode == false)
         settings.toggleContinuousMode()
         #expect(settings.isContinuousMode == true)
+        settings.toggleContinuousMode()
+        #expect(settings.isContinuousMode == false)
     }
 }

--- a/Tests/VimursorTests/ClickModifierTests.swift
+++ b/Tests/VimursorTests/ClickModifierTests.swift
@@ -1,0 +1,43 @@
+import Testing
+import CoreGraphics
+@testable import Vimursor
+
+@Suite
+struct ClickModifierTests {
+
+    @Test func noModifierReturnsLeftClick() {
+        #expect(ClickModifier.from(flags: []) == .leftClick)
+    }
+
+    @Test func commandReturnsCommandClick() {
+        #expect(ClickModifier.from(flags: .maskCommand) == .commandClick)
+    }
+
+    @Test func shiftReturnsRightClick() {
+        #expect(ClickModifier.from(flags: .maskShift) == .rightClick)
+    }
+
+    @Test func controlReturnsControlClick() {
+        #expect(ClickModifier.from(flags: .maskControl) == .controlClick)
+    }
+
+    @Test func optionReturnsOptionClick() {
+        #expect(ClickModifier.from(flags: .maskAlternate) == .optionClick)
+    }
+
+    @Test func commandTakesPriorityOverShift() {
+        #expect(ClickModifier.from(flags: [.maskCommand, .maskShift]) == .commandClick)
+    }
+
+    @Test func controlTakesPriorityOverOption() {
+        #expect(ClickModifier.from(flags: [.maskControl, .maskAlternate]) == .controlClick)
+    }
+
+    @Test func optionTakesPriorityOverShift() {
+        #expect(ClickModifier.from(flags: [.maskAlternate, .maskShift]) == .optionClick)
+    }
+
+    @Test func allModifiersPressedReturnsCommand() {
+        #expect(ClickModifier.from(flags: [.maskCommand, .maskControl, .maskAlternate, .maskShift]) == .commandClick)
+    }
+}

--- a/Tests/VimursorTests/HintModeControllerTests.swift
+++ b/Tests/VimursorTests/HintModeControllerTests.swift
@@ -126,6 +126,65 @@ struct HintModeControllerTests {
         #expect(overlay.showCallCount <= 1)
     }
 
+    // MARK: - 修飾キー付きクリック
+
+    @Test func cmdModifierPassesCommandClick() async throws {
+        let axRef = AXUIElementCreateSystemWide()
+        let axElement = AXElement(ref: axRef)
+        let info = UIElementInfo(
+            frame: CGRect(x: 100, y: 100, width: 50, height: 20),
+            label: "a",
+            axElement: axElement
+        )
+        let (controller, overlay, hotkey, fetcher) = makeSUT(elements: [info])
+        fetcher.clickableElements = [axElement]
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(50))
+        guard hotkey.keyEventHandler != nil else { return }
+
+        hotkey.simulateKey(0, flags: .maskCommand)  // keyCode 0 = "a"
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(fetcher.lastClickModifier == .commandClick)
+    }
+
+    @Test func shiftModifierPassesRightClick() async throws {
+        let axRef = AXUIElementCreateSystemWide()
+        let axElement = AXElement(ref: axRef)
+        let info = UIElementInfo(
+            frame: CGRect(x: 100, y: 100, width: 50, height: 20),
+            label: "a",
+            axElement: axElement
+        )
+        let (controller, overlay, hotkey, fetcher) = makeSUT(elements: [info])
+        fetcher.clickableElements = [axElement]
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(50))
+        guard hotkey.keyEventHandler != nil else { return }
+
+        hotkey.simulateKey(0, flags: .maskShift)
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(fetcher.lastClickModifier == .rightClick)
+    }
+
+    @Test func noModifierPassesLeftClick() async throws {
+        let axRef = AXUIElementCreateSystemWide()
+        let axElement = AXElement(ref: axRef)
+        let info = UIElementInfo(
+            frame: CGRect(x: 100, y: 100, width: 50, height: 20),
+            label: "a",
+            axElement: axElement
+        )
+        let (controller, overlay, hotkey, fetcher) = makeSUT(elements: [info])
+        fetcher.clickableElements = [axElement]
+        controller.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        try await Task.sleep(for: .milliseconds(50))
+        guard hotkey.keyEventHandler != nil else { return }
+
+        hotkey.simulateKey(0, flags: [])
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(fetcher.lastClickModifier == .leftClick)
+    }
+
     // MARK: - ESC キーで deactivate される
 
     @Test func escKeyDeactivates() async throws {

--- a/Tests/VimursorTests/Mocks/MockElementFetching.swift
+++ b/Tests/VimursorTests/Mocks/MockElementFetching.swift
@@ -11,6 +11,7 @@ final class MockElementFetching: ElementFetching, @unchecked Sendable {
     // 呼び出し記録
     var clickAtCallCount = 0
     var lastClickedFrame: CGRect?
+    var lastClickModifier: ClickModifier?
     var fetchClickableCallCount = 0
     var fetchSearchableCallCount = 0
     var fetchScrollableCallCount = 0
@@ -43,8 +44,9 @@ final class MockElementFetching: ElementFetching, @unchecked Sendable {
         }
     }
 
-    func clickAt(frame: CGRect) {
+    func clickAt(frame: CGRect, modifier: ClickModifier) {
         clickAtCallCount += 1
         lastClickedFrame = frame
+        lastClickModifier = modifier
     }
 }


### PR DESCRIPTION
## Summary

- ヒントモードでラベル入力時に修飾キーを押しながら入力することで、通常の左クリック以外のアクションを実行可能に（Vimium C 方式）
- `ClickModifier` 型で CGEventFlags → クリックアクションのマッピングを純粋ロジックとして定義
- `AXManager.clickAt` が右クリック・Cmd/Ctrl/Option+クリックに対応
- 連続ヒントモードのデフォルトをオフに変更

| 修飾キー | アクション |
|---------|-----------|
| なし | 左クリック（既存） |
| Cmd | Cmd+クリック |
| Shift | 右クリック |
| Ctrl | Ctrl+クリック |
| Option | Option+クリック |

Epic: #119
Closes #119, Closes #120, Closes #121, Closes #122

## Test plan

- [x] 修飾キーなしでラベル入力 → 従来通り左クリックが実行される
- [x] Cmd を押しながらラベル入力 → Cmd+クリック（ブラウザで新しいタブが開く等）
- [x] Shift を押しながらラベル入力 → 右クリック（コンテキストメニューが表示される）
- [x] Ctrl を押しながらラベル入力 → Ctrl+クリック
- [x] Option を押しながらラベル入力 → Option+クリック
- [x] 連続モードでも修飾キー付きクリックが動作する
- [x] `swift test` — 165 テスト全通過