### PR TITLE
feat: ヒントラベル水平位置設定（Left/Center/Right）

### DIFF
--- a/Sources/Vimursor/HintMode/HintView.swift
+++ b/Sources/Vimursor/HintMode/HintView.swift
@@ -40,12 +40,23 @@ final class HintView: NSView {
     }
 
     /// ラベルボックスの origin を計算する純粋関数。
-    /// NSWindow 座標系（原点: 左下）で、要素の左端・縦中央にラベルを配置する。
-    nonisolated static func labelOrigin(elementFrame: CGRect, boxHeight: CGFloat) -> CGPoint {
-        CGPoint(
-            x: elementFrame.minX,
-            y: elementFrame.midY - boxHeight / 2
-        )
+    /// NSWindow 座標系（原点: 左下）で、alignment に従った水平位置・縦中央にラベルを配置する。
+    nonisolated static func labelOrigin(
+        elementFrame: CGRect,
+        boxHeight: CGFloat,
+        boxWidth: CGFloat,
+        alignment: HintLabelAlignment
+    ) -> CGPoint {
+        let x: CGFloat
+        switch alignment {
+        case .left:
+            x = elementFrame.minX
+        case .center:
+            x = elementFrame.midX - boxWidth / 2
+        case .right:
+            x = elementFrame.maxX - boxWidth
+        }
+        return CGPoint(x: x, y: elementFrame.midY - boxHeight / 2)
     }
 
     private func drawLabel(hint: UIElementInfo, isMatch: Bool) {
@@ -62,8 +73,13 @@ final class HintView: NSView {
         let boxWidth = size.width + padding * 2
         let boxHeight = size.height + padding * 2
 
-        // ラベルをUI要素の左端・縦中央に配置（Vimiumスタイル）
-        let origin = HintView.labelOrigin(elementFrame: hint.frame, boxHeight: boxHeight)
+        // ラベルをalignment設定に従った水平位置・縦中央に配置
+        let origin = HintView.labelOrigin(
+            elementFrame: hint.frame,
+            boxHeight: boxHeight,
+            boxWidth: boxWidth,
+            alignment: settings.labelAlignment
+        )
         let boxRect = CGRect(x: origin.x, y: origin.y, width: boxWidth, height: boxHeight)
 
         let cornerRadius = HintLabelLayout.cornerRadius

--- a/Sources/Vimursor/Settings/AppSettings.swift
+++ b/Sources/Vimursor/Settings/AppSettings.swift
@@ -1,5 +1,13 @@
 import AppKit
 
+// MARK: - HintLabelAlignment
+
+enum HintLabelAlignment: String, Sendable, CaseIterable {
+    case left
+    case center
+    case right
+}
+
 // MARK: - UserDefaults キー定数
 
 enum AppSettingsKey {
@@ -9,6 +17,7 @@ enum AppSettingsKey {
     static let labelBackgroundColor = "appearance.labelBackgroundColor"
     static let labelBackgroundOpacity = "appearance.labelBackgroundOpacity"
     static let searchBarOpacity = "appearance.searchBarOpacity"
+    static let labelAlignment = "appearance.labelAlignment"
 
     // Behavior
     static let hintCharacterSet = "behavior.hintCharacterSet"
@@ -31,6 +40,7 @@ final class AppSettings: @unchecked Sendable {
         static let labelBackgroundColor: NSColor = .white
         static let labelBackgroundOpacity: CGFloat = 0.95
         static let searchBarOpacity: CGFloat = 1.0
+        static let labelAlignment: String = HintLabelAlignment.left.rawValue
         static let hintCharacterSet: String = "fjrieodkslapnvmc"
         static let isContinuousMode: Bool = false
         static let reactivationDelay: TimeInterval = 0.3
@@ -53,6 +63,7 @@ final class AppSettings: @unchecked Sendable {
             AppSettingsKey.labelFontSize: Defaults.labelFontSize,
             AppSettingsKey.labelBackgroundOpacity: Defaults.labelBackgroundOpacity,
             AppSettingsKey.searchBarOpacity: Defaults.searchBarOpacity,
+            AppSettingsKey.labelAlignment: Defaults.labelAlignment,
             AppSettingsKey.hintCharacterSet: Defaults.hintCharacterSet,
             AppSettingsKey.isContinuousMode: Defaults.isContinuousMode,
             AppSettingsKey.reactivationDelay: Defaults.reactivationDelay,
@@ -91,6 +102,14 @@ final class AppSettings: @unchecked Sendable {
         set { defaults.set(Double(newValue), forKey: AppSettingsKey.searchBarOpacity) }
     }
 
+    var labelAlignment: HintLabelAlignment {
+        get {
+            let raw = defaults.string(forKey: AppSettingsKey.labelAlignment) ?? Defaults.labelAlignment
+            return HintLabelAlignment(rawValue: raw) ?? .left
+        }
+        set { defaults.set(newValue.rawValue, forKey: AppSettingsKey.labelAlignment) }
+    }
+
     // MARK: - Behavior
 
     var hintCharacterSet: String {
@@ -123,6 +142,7 @@ final class AppSettings: @unchecked Sendable {
             AppSettingsKey.labelBackgroundColor,
             AppSettingsKey.labelBackgroundOpacity,
             AppSettingsKey.searchBarOpacity,
+            AppSettingsKey.labelAlignment,
             AppSettingsKey.hintCharacterSet,
             AppSettingsKey.isContinuousMode,
             AppSettingsKey.reactivationDelay,

--- a/Sources/Vimursor/Settings/AppearanceSettingsView.swift
+++ b/Sources/Vimursor/Settings/AppearanceSettingsView.swift
@@ -34,6 +34,7 @@ final class AppearanceSettingsView: NSView {
     private let bgOpacityField = NSTextField()
     private let searchBarOpacitySlider = NSSlider()
     private let searchBarOpacityField = NSTextField()
+    private let alignmentSegment = NSSegmentedControl()
 
     // MARK: - Initialization
 
@@ -96,6 +97,15 @@ final class AppearanceSettingsView: NSView {
         searchBarOpacityField.isEditable = false
         searchBarOpacityField.isBordered = true
         searchBarOpacityField.alignment = .right
+
+        // Label Alignment
+        alignmentSegment.segmentCount = 3
+        alignmentSegment.setLabel("Left", forSegment: 0)
+        alignmentSegment.setLabel("Center", forSegment: 1)
+        alignmentSegment.setLabel("Right", forSegment: 2)
+        alignmentSegment.selectedSegment = segmentIndex(for: settings.labelAlignment)
+        alignmentSegment.target = self
+        alignmentSegment.action = #selector(alignmentChanged(_:))
     }
 
     private func setupLayout() {
@@ -104,7 +114,8 @@ final class AppearanceSettingsView: NSView {
             ("Text Color:", [textColorWell]),
             ("Background Color:", [backgroundColorWell]),
             ("Background Opacity:", [bgOpacitySlider, bgOpacityField]),
-            ("Search Bar Opacity:", [searchBarOpacitySlider, searchBarOpacityField])
+            ("Search Bar Opacity:", [searchBarOpacitySlider, searchBarOpacityField]),
+            ("Label Position:", [alignmentSegment])
         ]
 
         for (index, row) in rows.enumerated() {
@@ -159,6 +170,13 @@ final class AppearanceSettingsView: NSView {
                 stepper.centerYAnchor.constraint(equalTo: topAnchor, constant: centerY)
             ])
             return Layout.stepperWidth + 4
+        case let segment as NSSegmentedControl:
+            NSLayoutConstraint.activate([
+                segment.leadingAnchor.constraint(equalTo: leadingAnchor, constant: xOffset),
+                segment.widthAnchor.constraint(equalToConstant: Layout.controlWidth),
+                segment.centerYAnchor.constraint(equalTo: topAnchor, constant: centerY)
+            ])
+            return Layout.controlWidth + 4
         default:
             NSLayoutConstraint.activate([
                 control.leadingAnchor.constraint(equalTo: leadingAnchor, constant: xOffset),
@@ -167,6 +185,10 @@ final class AppearanceSettingsView: NSView {
             ])
             return Layout.valueFieldWidth + 4
         }
+    }
+
+    private func segmentIndex(for alignment: HintLabelAlignment) -> Int {
+        HintLabelAlignment.allCases.firstIndex(of: alignment) ?? 0
     }
 
     private func makeLabel(_ text: String) -> NSTextField {
@@ -203,6 +225,12 @@ final class AppearanceSettingsView: NSView {
         settings.searchBarOpacity = CGFloat(value)
     }
 
+    @objc private func alignmentChanged(_ sender: NSSegmentedControl) {
+        let index = sender.selectedSegment
+        guard HintLabelAlignment.allCases.indices.contains(index) else { return }
+        settings.labelAlignment = HintLabelAlignment.allCases[index]
+    }
+
     // MARK: - Public
 
     /// 設定の現在値をコントロールに反映する（Reset 後などに使用）。
@@ -215,5 +243,6 @@ final class AppearanceSettingsView: NSView {
         bgOpacityField.stringValue = String(format: "%.2f", settings.labelBackgroundOpacity)
         searchBarOpacitySlider.doubleValue = Double(settings.searchBarOpacity)
         searchBarOpacityField.stringValue = String(format: "%.2f", settings.searchBarOpacity)
+        alignmentSegment.selectedSegment = segmentIndex(for: settings.labelAlignment)
     }
 }

--- a/Tests/VimursorTests/AppSettingsTests.swift
+++ b/Tests/VimursorTests/AppSettingsTests.swift
@@ -159,6 +159,33 @@ struct AppSettingsTests {
         #expect(settings.labelBackgroundColor == AppSettings.Defaults.labelBackgroundColor)
     }
 
+    // MARK: - labelAlignment
+
+    @Test("labelAlignment のデフォルト値は .left")
+    func defaultLabelAlignment() {
+        let settings = makeSettings()
+        #expect(settings.labelAlignment == .left)
+    }
+
+    @Test("labelAlignment の書き込みと読み出し、および無効値フォールバック")
+    func readWriteLabelAlignment() {
+        let settings = makeSettings()
+        settings.labelAlignment = .center
+        #expect(settings.labelAlignment == .center)
+
+        // 無効な rawValue を直接書き込んだ場合は .left にフォールバックする
+        settings.defaults.set("invalid", forKey: AppSettingsKey.labelAlignment)
+        #expect(settings.labelAlignment == .left)
+    }
+
+    @Test("resetToDefaults() で labelAlignment が .left に戻ること")
+    func resetLabelAlignment() {
+        let settings = makeSettings()
+        settings.labelAlignment = .right
+        settings.resetToDefaults()
+        #expect(settings.labelAlignment == .left)
+    }
+
     // MARK: - isContinuousMode キー互換性
 
     @Test("isContinuousMode は HintModeSettings と同じ UserDefaults キーを使う")

--- a/Tests/VimursorTests/HintViewTests.swift
+++ b/Tests/VimursorTests/HintViewTests.swift
@@ -15,7 +15,7 @@ struct HintViewTests {
         // 期待 origin: (100, 220 - 10) = (100, 210)
         let frame = CGRect(x: 100, y: 200, width: 80, height: 40)
         let boxHeight: CGFloat = 20
-        let origin = HintView.labelOrigin(elementFrame: frame, boxHeight: boxHeight)
+        let origin = HintView.labelOrigin(elementFrame: frame, boxHeight: boxHeight, boxWidth: 0, alignment: .left)
         #expect(origin.x == 100)
         #expect(origin.y == 210)
     }
@@ -28,7 +28,7 @@ struct HintViewTests {
         // 期待 origin: (50, 105 - 10) = (50, 95)
         let frame = CGRect(x: 50, y: 100, width: 30, height: 10)
         let boxHeight: CGFloat = 20
-        let origin = HintView.labelOrigin(elementFrame: frame, boxHeight: boxHeight)
+        let origin = HintView.labelOrigin(elementFrame: frame, boxHeight: boxHeight, boxWidth: 0, alignment: .left)
         #expect(origin.x == 50)
         #expect(origin.y == 95)
     }
@@ -41,7 +41,7 @@ struct HintViewTests {
         // 期待 origin: (0, 25 - 8) = (0, 17)
         let frame = CGRect(x: 0, y: 0, width: 100, height: 50)
         let boxHeight: CGFloat = 16
-        let origin = HintView.labelOrigin(elementFrame: frame, boxHeight: boxHeight)
+        let origin = HintView.labelOrigin(elementFrame: frame, boxHeight: boxHeight, boxWidth: 0, alignment: .left)
         #expect(origin.x == 0)
         #expect(origin.y == 17)
     }
@@ -54,8 +54,44 @@ struct HintViewTests {
         // 期待 origin: (10, 40 - 11) = (10, 29)
         let frame = CGRect(x: 10, y: 10, width: 60, height: 60)
         let boxHeight: CGFloat = 22
-        let origin = HintView.labelOrigin(elementFrame: frame, boxHeight: boxHeight)
+        let origin = HintView.labelOrigin(elementFrame: frame, boxHeight: boxHeight, boxWidth: 0, alignment: .left)
         #expect(origin.x == 10)
         #expect(origin.y == 29)
+    }
+
+    @Test("Left alignment: boxWidth があっても x は minX のまま")
+    func leftAlignmentIgnoresBoxWidth() {
+        let frame = CGRect(x: 100, y: 200, width: 80, height: 40)
+        let boxWidth: CGFloat = 30
+        let boxHeight: CGFloat = 20
+        let origin = HintView.labelOrigin(
+            elementFrame: frame, boxHeight: boxHeight, boxWidth: boxWidth, alignment: .left
+        )
+        #expect(origin.x == 100)
+        #expect(origin.y == 210)
+    }
+
+    @Test("Center alignment: x は midX - boxWidth/2")
+    func centerAlignment() {
+        let frame = CGRect(x: 100, y: 200, width: 80, height: 40)
+        let boxWidth: CGFloat = 30
+        let boxHeight: CGFloat = 20
+        let origin = HintView.labelOrigin(
+            elementFrame: frame, boxHeight: boxHeight, boxWidth: boxWidth, alignment: .center
+        )
+        #expect(origin.x == 125)
+        #expect(origin.y == 210)
+    }
+
+    @Test("Right alignment: x は maxX - boxWidth")
+    func rightAlignment() {
+        let frame = CGRect(x: 100, y: 200, width: 80, height: 40)
+        let boxWidth: CGFloat = 30
+        let boxHeight: CGFloat = 20
+        let origin = HintView.labelOrigin(
+            elementFrame: frame, boxHeight: boxHeight, boxWidth: boxWidth, alignment: .right
+        )
+        #expect(origin.x == 150)
+        #expect(origin.y == 210)
     }
 }


### PR DESCRIPTION
## Summary

- ヒントモードのラベル水平位置を Appearance 設定画面から Left / Center / Right で選択可能に
- `HintLabelAlignment` enum（`CaseIterable`）で位置オプションを定義
- `HintView.labelOrigin` に `boxWidth` / `alignment` パラメータを追加
- `AppearanceSettingsView` に NSSegmentedControl を追加
- デフォルトは Left（既存動作と同一）

| 設定 | X 座標 |
|------|--------|
| Left | `elementFrame.minX` |
| Center | `elementFrame.midX - boxWidth / 2` |
| Right | `elementFrame.maxX - boxWidth` |

Epic: #124
Closes #124, Closes #125

## Test plan

- [x] デフォルト（Left）でラベルが要素の左端に表示される
- [x] Center に変更するとラベルが要素の中央に表示される
- [x] Right に変更するとラベルが要素の右端に表示される
- [x] 設定がアプリ再起動後も保持される
- [x] Reset to Defaults で Left に戻る
- [x] `swift test` — 171 テスト全通過