### PR TITLE
perf: パフォーマンス最適化（IPC削減・描画キャッシュ・1パス化）

### DIFF
--- a/Sources/Vimursor/Accessibility/AXAttributes.swift
+++ b/Sources/Vimursor/Accessibility/AXAttributes.swift
@@ -3,6 +3,9 @@ import AppKit
 /// AXUIElement の属性取得を安全に行う共通ユーティリティ。
 /// 座標は AX スクリーン座標系（原点:左上）で返す。
 enum AXAttributes {
+    /// 属性未サポート時に NSNull を返し、残りの属性取得を続行するオプション。
+    static let continueOnError = AXCopyMultipleAttributeOptions(rawValue: 0)
+
     /// AXUIElement の AXPosition + AXSize から CGRect を取得する。
     /// AXUIElementCopyMultipleAttributeValues で1 IPC にまとめて取得する。
     /// - Returns: AX座標（原点:左上）の CGRect。取得失敗時は nil。
@@ -11,7 +14,7 @@ enum AXAttributes {
         let err = AXUIElementCopyMultipleAttributeValues(
             element,
             ["AXPosition", "AXSize"] as CFArray,
-            AXCopyMultipleAttributeOptions(rawValue: 0),
+            AXAttributes.continueOnError,
             &values
         )
         guard err == .success,

--- a/Sources/Vimursor/Accessibility/AXAttributes.swift
+++ b/Sources/Vimursor/Accessibility/AXAttributes.swift
@@ -4,14 +4,22 @@ import AppKit
 /// 座標は AX スクリーン座標系（原点:左上）で返す。
 enum AXAttributes {
     /// AXUIElement の AXPosition + AXSize から CGRect を取得する。
+    /// AXUIElementCopyMultipleAttributeValues で1 IPC にまとめて取得する。
     /// - Returns: AX座標（原点:左上）の CGRect。取得失敗時は nil。
     static func frame(of element: AXUIElement) -> CGRect? {
-        var posRef: CFTypeRef?
-        var sizeRef: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(element, "AXPosition" as CFString, &posRef) == .success,
-              AXUIElementCopyAttributeValue(element, "AXSize" as CFString, &sizeRef) == .success,
-              let posRef, let sizeRef else { return nil }
-        return rectFromValues(positionValue: posRef, sizeValue: sizeRef)
+        var values: CFArray?
+        let err = AXUIElementCopyMultipleAttributeValues(
+            element,
+            ["AXPosition", "AXSize"] as CFArray,
+            AXCopyMultipleAttributeOptions(rawValue: 0),
+            &values
+        )
+        guard err == .success,
+              let arr = values as? [Any],
+              arr.count == 2,
+              !(arr[0] is NSNull),
+              !(arr[1] is NSNull) else { return nil }
+        return rectFromValues(positionValue: arr[0] as CFTypeRef, sizeValue: arr[1] as CFTypeRef)
     }
 
     /// CFTypeRef から CGRect を構築する純粋ロジック（テスト用に分離）。

--- a/Sources/Vimursor/Accessibility/AXManager.swift
+++ b/Sources/Vimursor/Accessibility/AXManager.swift
@@ -19,9 +19,16 @@ struct SearchElementInfo: Sendable {
     let description: String
     let role: String
     let axElement: AXElement
+    let searchableText: String
 
-    var searchableText: String {
-        [title, label, description, role]
+    init(frame: CGRect, title: String, label: String, description: String, role: String, axElement: AXElement) {
+        self.frame = frame
+        self.title = title
+        self.label = label
+        self.description = description
+        self.role = role
+        self.axElement = axElement
+        self.searchableText = [title, label, description, role]
             .filter { !$0.isEmpty }
             .joined(separator: " ")
             .lowercased()
@@ -67,21 +74,15 @@ final class AXManager: @unchecked Sendable {
         let screenHeight = NSScreen.main?.frame.height ?? 0
         DispatchQueue.global(qos: .userInitiated).async {
             let elements = UIElementEnumerator.enumerateSearchableElements(root: wrapped.ref)
-            let infos = elements.compactMap { el -> SearchElementInfo? in
-                guard let frame = self.fetchFrame(element: el, screenHeight: screenHeight) else { return nil }
-                func str(_ key: String) -> String {
-                    var ref: CFTypeRef?
-                    guard AXUIElementCopyAttributeValue(el, key as CFString, &ref) == .success,
-                          let s = ref as? String else { return "" }
-                    return s
-                }
+            let infos = elements.compactMap { data -> SearchElementInfo? in
+                guard let frame = self.fetchFrame(element: data.element, screenHeight: screenHeight) else { return nil }
                 return SearchElementInfo(
                     frame: frame,
-                    title: str("AXTitle"),
-                    label: str("AXLabel"),
-                    description: str("AXDescription"),
-                    role: str("AXRole"),
-                    axElement: AXElement(ref: el)
+                    title: data.title,
+                    label: data.label,
+                    description: data.description,
+                    role: data.role,
+                    axElement: AXElement(ref: data.element)
                 )
             }
             DispatchQueue.main.async { completion(infos) }

--- a/Sources/Vimursor/Accessibility/UIElementEnumerator.swift
+++ b/Sources/Vimursor/Accessibility/UIElementEnumerator.swift
@@ -81,6 +81,12 @@ enum UIElementEnumerator {
         return enabled
     }
 
+    /// テキスト属性のうち、空白のみでない値が1つでもあるかを判定する。
+    /// テスト用に公開。
+    static func hasNonEmptyText(title: String, label: String, description: String) -> Bool {
+        [title, label, description].contains { !$0.isEmpty && $0.contains { !$0.isWhitespace } }
+    }
+
     static func enumerateSearchableElements(root: AXUIElement) -> [SearchableElementData] {
         var result: [SearchableElementData] = []
         collectVisible(element: root, into: &result, depth: 0)
@@ -103,7 +109,7 @@ enum UIElementEnumerator {
         if AXUIElementCopyMultipleAttributeValues(
             element,
             ["AXTitle", "AXLabel", "AXDescription", "AXRole"] as CFArray,
-            AXCopyMultipleAttributeOptions(rawValue: 0),
+            AXAttributes.continueOnError,
             &valuesRef
         ) == .success, let attrs = valuesRef as? [Any], attrs.count == 4 {
             let title = (attrs[0] as? String) ?? ""
@@ -111,8 +117,7 @@ enum UIElementEnumerator {
             let desc  = (attrs[2] as? String) ?? ""
             let role  = (attrs[3] as? String) ?? ""
 
-            let hasText = [title, label, desc].contains { !$0.isEmpty && $0.contains { !$0.isWhitespace } }
-            if hasText {
+            if hasNonEmptyText(title: title, label: label, description: desc) {
                 result.append(SearchableElementData(
                     element: element, title: title, label: label, description: desc, role: role
                 ))

--- a/Sources/Vimursor/Accessibility/UIElementEnumerator.swift
+++ b/Sources/Vimursor/Accessibility/UIElementEnumerator.swift
@@ -1,5 +1,14 @@
 import AppKit
 
+/// 検索モード用の要素データ（AX属性を1パスで取得済み）
+struct SearchableElementData {
+    let element: AXUIElement
+    let title: String
+    let label: String
+    let description: String
+    let role: String
+}
+
 private enum Limits {
     /// クリック可能要素探索の最大深さ（無限再帰防止）
     static let clickableMaxDepth = 25
@@ -72,15 +81,15 @@ enum UIElementEnumerator {
         return enabled
     }
 
-    static func enumerateSearchableElements(root: AXUIElement) -> [AXUIElement] {
-        var result: [AXUIElement] = []
+    static func enumerateSearchableElements(root: AXUIElement) -> [SearchableElementData] {
+        var result: [SearchableElementData] = []
         collectVisible(element: root, into: &result, depth: 0)
         return result
     }
 
     private static func collectVisible(
         element: AXUIElement,
-        into result: inout [AXUIElement],
+        into result: inout [SearchableElementData],
         depth: Int
     ) {
         guard depth < Limits.searchableMaxDepth, result.count < Limits.searchableMaxCount else { return }
@@ -89,14 +98,26 @@ enum UIElementEnumerator {
         if AXUIElementCopyAttributeValue(element, "AXHidden" as CFString, &hiddenRef) == .success,
            let hidden = hiddenRef as? Bool, hidden { return }
 
-        let searchKeys = ["AXTitle", "AXLabel", "AXDescription"]
-        let hasText = searchKeys.contains { key in
-            var ref: CFTypeRef?
-            guard AXUIElementCopyAttributeValue(element, key as CFString, &ref) == .success,
-                  let s = ref as? String else { return false }
-            return !s.trimmingCharacters(in: .whitespaces).isEmpty
+        // AXTitle, AXLabel, AXDescription, AXRole を 1 IPC でバッチ取得
+        var valuesRef: CFArray?
+        if AXUIElementCopyMultipleAttributeValues(
+            element,
+            ["AXTitle", "AXLabel", "AXDescription", "AXRole"] as CFArray,
+            AXCopyMultipleAttributeOptions(rawValue: 0),
+            &valuesRef
+        ) == .success, let attrs = valuesRef as? [Any], attrs.count == 4 {
+            let title = (attrs[0] as? String) ?? ""
+            let label = (attrs[1] as? String) ?? ""
+            let desc  = (attrs[2] as? String) ?? ""
+            let role  = (attrs[3] as? String) ?? ""
+
+            let hasText = [title, label, desc].contains { !$0.isEmpty && $0.contains { !$0.isWhitespace } }
+            if hasText {
+                result.append(SearchableElementData(
+                    element: element, title: title, label: label, description: desc, role: role
+                ))
+            }
         }
-        if hasText { result.append(element) }
 
         var childrenRef: CFTypeRef?
         let err = AXUIElementCopyAttributeValue(element, "AXChildren" as CFString, &childrenRef)

--- a/Sources/Vimursor/HintMode/HintView.swift
+++ b/Sources/Vimursor/HintMode/HintView.swift
@@ -14,6 +14,8 @@ final class HintView: NSView {
     private var hints: [UIElementInfo] = []
     private var inputPrefix: String = ""
     private let settings: AppSettings
+    private var matchAttrs: [NSAttributedString.Key: Any] = [:]
+    private var noMatchAttrs: [NSAttributedString.Key: Any] = [:]
 
     init(frame: NSRect, settings: AppSettings = .shared) {
         self.settings = settings
@@ -27,6 +29,9 @@ final class HintView: NSView {
     func update(hints: [UIElementInfo], inputPrefix: String) {
         self.hints = hints
         self.inputPrefix = inputPrefix
+        let font = NSFont.systemFont(ofSize: settings.labelFontSize, weight: .semibold)
+        matchAttrs = [.font: font, .foregroundColor: settings.labelTextColor]
+        noMatchAttrs = [.font: font, .foregroundColor: NSColor.gray]
         needsDisplay = true
     }
 
@@ -34,6 +39,8 @@ final class HintView: NSView {
         super.draw(dirtyRect)
 
         for hint in hints {
+            let expandedFrame = hint.frame.insetBy(dx: -50, dy: -50)
+            guard expandedFrame.intersects(dirtyRect) else { continue }
             let isMatch = inputPrefix.isEmpty || hint.label.hasPrefix(inputPrefix)
             drawLabel(hint: hint, isMatch: isMatch)
         }
@@ -61,12 +68,7 @@ final class HintView: NSView {
 
     private func drawLabel(hint: UIElementInfo, isMatch: Bool) {
         let label = hint.label
-        let font = NSFont.systemFont(ofSize: settings.labelFontSize, weight: .semibold)
-        let textColor: NSColor = isMatch ? settings.labelTextColor : .gray
-        let attrs: [NSAttributedString.Key: Any] = [
-            .font: font,
-            .foregroundColor: textColor
-        ]
+        let attrs = isMatch ? matchAttrs : noMatchAttrs
 
         let size = (label as NSString).size(withAttributes: attrs)
         let padding = HintLabelLayout.padding

--- a/Sources/Vimursor/Overlay/LabelGenerator.swift
+++ b/Sources/Vimursor/Overlay/LabelGenerator.swift
@@ -17,6 +17,7 @@ struct LabelGenerator {
 
         // count が多い場合は全部2文字ラベル（最大 N×N）
         var labels: [String] = []
+        labels.reserveCapacity(clampedCount)
         for first in chars {
             for second in chars {
                 guard labels.count < clampedCount else { break }

--- a/Sources/Vimursor/ScrollMode/ScrollEngine.swift
+++ b/Sources/Vimursor/ScrollMode/ScrollEngine.swift
@@ -53,6 +53,7 @@ enum ScrollEngine {
         let pixelsPerEvent: Int32 = 5_000
         let eventCount = 10
         let pixels = direction == .up ? pixelsPerEvent : -pixelsPerEvent
+        let source = CGEventSource(stateID: .combinedSessionState)
 
         // cancel() でキャンセルフラグを立てるためのセンチネル
         let sentinel = DispatchWorkItem { }
@@ -60,7 +61,7 @@ enum ScrollEngine {
             DispatchQueue.global().asyncAfter(deadline: .now() + Double(i) * 0.02) {
                 guard !sentinel.isCancelled else { return }
                 let event = CGEvent(
-                    scrollWheelEvent2Source: nil,
+                    scrollWheelEvent2Source: source,
                     units: .pixel,
                     wheelCount: 1,
                     wheel1: pixels,

--- a/Sources/Vimursor/SearchMode/SearchModeController.swift
+++ b/Sources/Vimursor/SearchMode/SearchModeController.swift
@@ -199,19 +199,20 @@ final class SearchModeController {
         guard let char = KeyCodeMapping.charFromKeyCode(keyCode) else { return }
 
         let newInput = input + char
-        let filtered = zip(labels, matched).filter { label, _ in
-            label.hasPrefix(newInput)
+        var exactMatchFrame: CGRect?
+        var hasPrefixMatch = false
+
+        for (label, element) in zip(labels, matched) {
+            if label == newInput {
+                exactMatchFrame = element.frame
+                break
+            }
+            if label.hasPrefix(newInput) {
+                hasPrefixMatch = true
+            }
         }
 
-        if filtered.isEmpty {
-            // マッチなし → deactivate
-            deactivate()
-            return
-        }
-
-        // 完全一致チェック
-        if let exactMatch = filtered.first(where: { label, _ in label == newInput }) {
-            let frame = exactMatch.1.frame
+        if let frame = exactMatchFrame {
             deactivate()
             Task { @MainActor [weak self] in
                 do {
@@ -221,6 +222,12 @@ final class SearchModeController {
                 }
                 self?.elementFetcher.clickAt(frame: frame)
             }
+            return
+        }
+
+        if !hasPrefixMatch {
+            // マッチなし → deactivate
+            deactivate()
             return
         }
 

--- a/Sources/Vimursor/SearchMode/SearchView.swift
+++ b/Sources/Vimursor/SearchMode/SearchView.swift
@@ -57,6 +57,8 @@ final class SearchView: NSView {
 
     /// selecting 状態のデータ（nil = searching 状態）
     private var selectingData: SelectingData?
+    private var matchAttrs: [NSAttributedString.Key: Any] = [:]
+    private var noMatchAttrs: [NSAttributedString.Key: Any] = [:]
 
     // ブラー効果付きフローティングバーのコンテナ
     private let blurContainer: NSVisualEffectView
@@ -212,6 +214,9 @@ final class SearchView: NSView {
     /// selecting 状態に入る時・ラベル入力更新時に呼ぶ
     func updateForSelecting(matched: [SearchElementInfo], labels: [String], input: String) {
         selectingData = SelectingData(matched: matched, labels: labels, input: input)
+        let font = NSFont.systemFont(ofSize: settings.labelFontSize, weight: .semibold)
+        matchAttrs = [.font: font, .foregroundColor: settings.labelTextColor]
+        noMatchAttrs = [.font: font, .foregroundColor: NSColor.gray]
         searchField.isEditable = false
         selectingOverlay.isHidden = false
         unfocusSearchField()
@@ -266,12 +271,7 @@ final class SearchView: NSView {
     }
 
     private func drawLabel(label: String, frame: CGRect, isMatch: Bool) {
-        let font = NSFont.systemFont(ofSize: settings.labelFontSize, weight: .semibold)
-        let textColor: NSColor = isMatch ? settings.labelTextColor : .gray
-        let attrs: [NSAttributedString.Key: Any] = [
-            .font: font,
-            .foregroundColor: textColor
-        ]
+        let attrs = isMatch ? matchAttrs : noMatchAttrs
 
         let size = (label as NSString).size(withAttributes: attrs)
         let padding = LabelStyle.padding

--- a/Tests/VimursorTests/UIElementEnumeratorTests.swift
+++ b/Tests/VimursorTests/UIElementEnumeratorTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import Vimursor
+
+@Suite("UIElementEnumerator Tests")
+struct UIElementEnumeratorTests {
+
+    @Test("テキストがある場合は true")
+    func hasTextWithTitle() {
+        #expect(UIElementEnumerator.hasNonEmptyText(title: "OK", label: "", description: ""))
+    }
+
+    @Test("全て空文字の場合は false")
+    func hasTextAllEmpty() {
+        #expect(!UIElementEnumerator.hasNonEmptyText(title: "", label: "", description: ""))
+    }
+
+    @Test("空白のみの場合は false")
+    func hasTextWhitespaceOnly() {
+        #expect(!UIElementEnumerator.hasNonEmptyText(title: "   ", label: "", description: ""))
+    }
+
+    @Test("改行のみの場合は false")
+    func hasTextNewlineOnly() {
+        #expect(!UIElementEnumerator.hasNonEmptyText(title: "\n", label: "\t", description: ""))
+    }
+
+    @Test("description にテキストがあれば true")
+    func hasTextInDescription() {
+        #expect(UIElementEnumerator.hasNonEmptyText(title: "", label: "", description: "hello"))
+    }
+
+    @Test("label にテキストがあれば true")
+    func hasTextInLabel() {
+        #expect(UIElementEnumerator.hasNonEmptyText(title: "", label: "btn", description: ""))
+    }
+}


### PR DESCRIPTION
## Summary

- `SearchElementInfo.searchableText` を computed var から let stored property に変更（毎回の再計算を排除）
- 検索モードの AX 属性取得を `AXUIElementCopyMultipleAttributeValues` で1パスに統合（要素あたり IPC 9回→2回）
- `AXAttributes.frame` で AXPosition + AXSize を1回の IPC で取得
- `HintView` / `SearchView` の `drawLabel` で NSFont/attrs を `update()` 時にキャッシュ
- `HintView.draw` で `dirtyRect` 外のヒントをスキップ
- `handleSelectingKey` の zip 走査を1パスに統合
- `LabelGenerator` に `reserveCapacity` 追加
- `ScrollEngine.scrollToExtreme` で `CGEventSource` を使い回し
- `hasNonEmptyText` をテスタブルに抽出しテスト6件追加

Epic: #127
Closes #127, Closes #128, Closes #129, Closes #130, Closes #131, Closes #132

## Test plan

- [x] ヒントモードが従来通り動作する（ラベル表示・クリック・消去）
- [x] 検索モードが従来通り動作する（テキスト検索・ラベル選択・クリック）
- [x] スクロールモードが従来通り動作する（j/k/gg/G）
- [x] `swift test` — 177 テスト全通過