### PR TITLE
feat: カーソル移動モード（Cmd+Shift+K）

### DIFF
--- a/Sources/Vimursor/AppDelegate.swift
+++ b/Sources/Vimursor/AppDelegate.swift
@@ -8,6 +8,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hintModeController: HintModeController?
     private var searchModeController: SearchModeController?
     private var scrollModeController: ScrollModeController?
+    private var cursorModeController: CursorModeController?
     private var statusBarController: StatusBarController?
     private var settingsWindowController: SettingsWindowController?
     private var permissionMonitor: AccessibilityPermissionMonitor?
@@ -32,6 +33,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         self.hintModeController = HintModeController(settings: appSettings)
         self.searchModeController = SearchModeController()
         self.scrollModeController = ScrollModeController()
+        self.cursorModeController = CursorModeController()
 
         // ログイン時起動マネージャを生成し、システム状態と同期する
         let loginManager = LoginItemManager()
@@ -48,6 +50,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             onHintMode: { [weak self] in self?.hotkeyManager?.onHintModeActivated?() },
             onSearchMode: { [weak self] in self?.hotkeyManager?.onSearchModeActivated?() },
             onScrollMode: { [weak self] in self?.hotkeyManager?.onScrollModeActivated?() },
+            onCursorMode: { [weak self] in self?.hotkeyManager?.onCursorModeActivated?() },
             onSettings: { [weak settingsController] in settingsController?.showSettingsWindow() },
             loginItemManager: loginManager,
             settings: appSettings
@@ -88,6 +91,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         KeyboardShortcuts.onKeyUp(for: .scrollMode) { [weak self] in
             self?.hotkeyManager?.onScrollModeActivated?()
         }
+        KeyboardShortcuts.onKeyUp(for: .cursorMode) { [weak self] in
+            self?.hotkeyManager?.onCursorModeActivated?()
+        }
     }
 
     // MARK: - HotkeyManager setup
@@ -118,6 +124,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                   hotkey.keyEventHandler == nil else { return }
             AXManager.enableManualAccessibility()
             self.scrollModeController?.activate(overlayWindow: overlay, hotkeyManager: hotkey)
+        }
+        manager.onCursorModeActivated = { [weak self] in
+            guard let self,
+                  let overlay = self.overlayWindow,
+                  let hotkey = self.hotkeyManager,
+                  hotkey.keyEventHandler == nil else { return }
+            self.cursorModeController?.activate(overlayWindow: overlay, hotkeyManager: hotkey)
         }
         self.hotkeyManager = manager
         manager.start()

--- a/Sources/Vimursor/CursorMode/CursorEngine.swift
+++ b/Sources/Vimursor/CursorMode/CursorEngine.swift
@@ -1,0 +1,67 @@
+import CoreGraphics
+import AppKit
+
+enum CursorDirection {
+    case left, down, up, right
+}
+
+enum CursorEngine {
+    /// カーソルの新しい位置を計算する純粋関数。画面端でクランプする。
+    /// - Parameters:
+    ///   - current: 現在のカーソル位置（スクリーン座標、原点:左上）
+    ///   - direction: 移動方向
+    ///   - steps: ステップ数（マルチプライヤ適用済み）
+    ///   - stepPixels: 1ステップあたりのピクセル数
+    ///   - screenBounds: スクリーンの矩形（原点:左上、通常 (0,0,width,height)）
+    static func moveCursor(
+        from current: CGPoint,
+        direction: CursorDirection,
+        steps: Int,
+        stepPixels: Int,
+        screenBounds: CGRect
+    ) -> CGPoint {
+        let delta = CGFloat(steps * stepPixels)
+        var newX = current.x
+        var newY = current.y
+
+        switch direction {
+        case .left:  newX -= delta
+        case .right: newX += delta
+        case .up:    newY -= delta  // screen coords: origin top-left, up = y decreases
+        case .down:  newY += delta  // down = y increases
+        }
+
+        // Clamp to screen bounds
+        newX = max(screenBounds.minX, min(screenBounds.maxX, newX))
+        newY = max(screenBounds.minY, min(screenBounds.maxY, newY))
+
+        return CGPoint(x: newX, y: newY)
+    }
+
+    /// カーソルを指定位置に移動する（副作用あり）
+    static func applyMove(to point: CGPoint) {
+        CGWarpMouseCursorPosition(point)
+    }
+
+    /// 指定位置でクリックを実行する（副作用あり）
+    /// - Parameters:
+    ///   - point: クリック位置（スクリーン座標、原点:左上）
+    ///   - isRightClick: true なら右クリック、false なら左クリック
+    static func click(at point: CGPoint, isRightClick: Bool) {
+        let downType: CGEventType = isRightClick ? .rightMouseDown : .leftMouseDown
+        let upType: CGEventType = isRightClick ? .rightMouseUp : .leftMouseUp
+        let button: CGMouseButton = isRightClick ? .right : .left
+
+        let down = CGEvent(mouseEventSource: nil, mouseType: downType,
+                           mouseCursorPosition: point, mouseButton: button)
+        let up = CGEvent(mouseEventSource: nil, mouseType: upType,
+                         mouseCursorPosition: point, mouseButton: button)
+        down?.post(tap: .cghidEventTap)
+        up?.post(tap: .cghidEventTap)
+    }
+
+    /// NSEvent.mouseLocation（原点:左下）をスクリーン座標（原点:左上）に変換する
+    static func screenPointFromMouseLocation(_ mouseLocation: CGPoint, screenHeight: CGFloat) -> CGPoint {
+        CGPoint(x: mouseLocation.x, y: screenHeight - mouseLocation.y)
+    }
+}

--- a/Sources/Vimursor/CursorMode/CursorModeController.swift
+++ b/Sources/Vimursor/CursorMode/CursorModeController.swift
@@ -135,20 +135,12 @@ final class CursorModeController {
         }
     }
 
+    private static let digitKeyCodeMap: [CGKeyCode: String] = [
+        29: "0", 18: "1", 19: "2", 20: "3", 21: "4",
+        23: "5", 22: "6", 26: "7", 28: "8", 25: "9"
+    ]
+
     private func digitFromKeyCode(_ keyCode: CGKeyCode) -> String? {
-        // Number row key codes (US keyboard)
-        switch keyCode {
-        case 29: return "0"
-        case 18: return "1"
-        case 19: return "2"
-        case 20: return "3"
-        case 21: return "4"
-        case 23: return "5"
-        case 22: return "6"
-        case 26: return "7"
-        case 28: return "8"
-        case 25: return "9"
-        default: return nil
-        }
+        Self.digitKeyCodeMap[keyCode]
     }
 }

--- a/Sources/Vimursor/CursorMode/CursorModeController.swift
+++ b/Sources/Vimursor/CursorMode/CursorModeController.swift
@@ -1,0 +1,154 @@
+import AppKit
+
+@MainActor
+final class CursorModeController {
+    private var isActive = false
+    private var cursorView: CursorView?
+    private weak var overlayWindow: (any OverlayProviding)?
+    private weak var hotkeyManager: (any KeyEventHandling)?
+    private let settings: AppSettings
+    private var multiplierBuffer: String = ""
+
+    init(settings: AppSettings = .shared) {
+        self.settings = settings
+    }
+
+    func activate(overlayWindow: any OverlayProviding, hotkeyManager: any KeyEventHandling) {
+        guard !isActive else { return }
+        isActive = true
+
+        self.overlayWindow = overlayWindow
+        self.hotkeyManager = hotkeyManager
+
+        let view = CursorView(frame: overlayWindow.contentView?.bounds ?? .zero, settings: settings)
+        view.autoresizingMask = [.width, .height]
+
+        // Get current cursor position in NSView coordinates (origin: bottom-left)
+        let mouseLocation = NSEvent.mouseLocation
+        view.update(cursorPosition: mouseLocation)
+
+        overlayWindow.contentView?.addSubview(view)
+        cursorView = view
+        overlayWindow.show()
+
+        // Set key event handler
+        hotkeyManager.keyEventHandler = { [weak self] keyCode, flags, _ in
+            guard let self else { return false }
+            Task { @MainActor [weak self] in
+                self?.handleKey(keyCode: keyCode, flags: flags)
+            }
+            return true  // consume all keys while active
+        }
+    }
+
+    func deactivate() {
+        isActive = false
+        multiplierBuffer = ""
+        cursorView?.removeFromSuperview()
+        cursorView = nil
+        hotkeyManager?.keyEventHandler = nil
+        overlayWindow?.hide()
+    }
+
+    private func handleKey(keyCode: CGKeyCode, flags: CGEventFlags) {
+        guard isActive else { return }
+
+        // ESC → deactivate
+        if keyCode == KeyCodeMapping.escapeKeyCode {
+            deactivate()
+            return
+        }
+
+        // Ignore modifier-only keys (Cmd+Tab etc.)
+        guard flags.isDisjoint(with: [.maskCommand, .maskControl, .maskAlternate]) else { return }
+
+        // Enter → click
+        let returnKeyCode: CGKeyCode = 36
+        if keyCode == returnKeyCode {
+            let isRightClick = flags.contains(.maskShift)
+            performClick(isRightClick: isRightClick)
+            return
+        }
+
+        // Number keys → accumulate multiplier
+        if let digit = digitFromKeyCode(keyCode) {
+            multiplierBuffer += digit
+            return
+        }
+
+        // Direction keys (hjkl)
+        if let direction = directionFromKeyCode(keyCode) {
+            let steps = Int(multiplierBuffer) ?? 1
+            multiplierBuffer = ""
+            performMove(direction: direction, steps: steps)
+            return
+        }
+
+        // Unknown key → ignore (don't deactivate)
+    }
+
+    private func performMove(direction: CursorDirection, steps: Int) {
+        let screenHeight = NSScreen.main?.frame.height ?? 0
+        let mouseLocation = NSEvent.mouseLocation
+        let currentScreenPoint = CursorEngine.screenPointFromMouseLocation(mouseLocation, screenHeight: screenHeight)
+        let screenBounds = CGRect(x: 0, y: 0, width: NSScreen.main?.frame.width ?? 1920, height: screenHeight)
+
+        let newPoint = CursorEngine.moveCursor(
+            from: currentScreenPoint,
+            direction: direction,
+            steps: steps,
+            stepPixels: settings.cursorStepPixels,
+            screenBounds: screenBounds
+        )
+
+        CursorEngine.applyMove(to: newPoint)
+
+        // Update view with new cursor position (convert back to NSView coords)
+        let newMouseLocation = CGPoint(x: newPoint.x, y: screenHeight - newPoint.y)
+        cursorView?.update(cursorPosition: newMouseLocation)
+    }
+
+    private func performClick(isRightClick: Bool) {
+        let screenHeight = NSScreen.main?.frame.height ?? 0
+        let mouseLocation = NSEvent.mouseLocation
+        let screenPoint = CursorEngine.screenPointFromMouseLocation(mouseLocation, screenHeight: screenHeight)
+
+        deactivate()
+        CursorEngine.click(at: screenPoint, isRightClick: isRightClick)
+    }
+
+    // MARK: - Key code helpers
+
+    /// Parse multiplier from accumulated buffer.
+    /// Exposed for testing.
+    nonisolated static func parseMultiplier(_ buffer: String) -> Int {
+        Int(buffer) ?? 1
+    }
+
+    private func directionFromKeyCode(_ keyCode: CGKeyCode) -> CursorDirection? {
+        switch keyCode {
+        case 4:  return .left   // h
+        case 38: return .down   // j
+        case 40: return .up     // k
+        case 37: return .right  // l
+        default: return nil
+        }
+    }
+
+    private func digitFromKeyCode(_ keyCode: CGKeyCode) -> String? {
+        // Number row key codes (US keyboard)
+        switch keyCode {
+        case 29: return "0"
+        case 18: return "1"
+        case 19: return "2"
+        case 20: return "3"
+        case 21: return "4"
+        case 23: return "5"
+        case 22: return "6"
+        case 26: return "7"
+        case 28: return "8"
+        case 25: return "9"
+        default: return nil
+        }
+    }
+}

--- a/Sources/Vimursor/CursorMode/CursorView.swift
+++ b/Sources/Vimursor/CursorMode/CursorView.swift
@@ -1,0 +1,199 @@
+import AppKit
+
+// MARK: - 描画定数
+
+private enum CursorViewLayout {
+    static let crosshairAlpha: CGFloat = 0.8
+    static let crosshairWidth: CGFloat = 1.0
+    static let guideLineAlpha: CGFloat = 0.3
+    static let guideLineWidth: CGFloat = 0.5
+    static let labelAlpha: CGFloat = 0.7
+    static let labelFontSize: CGFloat = 10
+    static let labelOffsetX: CGFloat = 8
+    static let labelOffsetY: CGFloat = 2
+    static let verticalLabelOffsetX: CGFloat = 4
+    static let verticalLabelOffsetY: CGFloat = 8
+    static let indicatorFontSize: CGFloat = 14
+    static let indicatorPadding: CGFloat = 8
+    static let indicatorCornerRadius: CGFloat = 6
+    static let indicatorBorderWidth: CGFloat = 1.5
+    static let indicatorMargin: CGFloat = 20
+    static let indicatorBgAlpha: CGFloat = 0.7
+}
+
+final class CursorView: NSView {
+    private var cursorPosition: CGPoint = .zero
+    private let settings: AppSettings
+
+    init(frame: NSRect, settings: AppSettings = .shared) {
+        self.settings = settings
+        super.init(frame: frame)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.clear.cgColor
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    func update(cursorPosition: CGPoint) {
+        self.cursorPosition = cursorPosition
+        needsDisplay = true
+    }
+
+    /// ガイドラインのオフセットとステップ数を計算する純粋関数。
+    /// 5ステップ間隔で、画面端まで生成する。
+    /// - Parameters:
+    ///   - origin: 起点座標（1次元）
+    ///   - stepPixels: 1ステップあたりのピクセル数
+    ///   - positiveMax: 正方向の最大距離（origin から画面端まで）
+    ///   - negativeMax: 負方向の最大距離（origin から画面端まで）
+    /// - Returns: (offset from origin in pixels, step count) pairs. Offset can be positive or negative.
+    nonisolated static func guideLineOffsets(
+        origin: CGFloat,
+        stepPixels: CGFloat,
+        positiveMax: CGFloat,
+        negativeMax: CGFloat
+    ) -> [(offset: CGFloat, stepCount: Int)] {
+        guard stepPixels > 0 else { return [] }
+        var result: [(CGFloat, Int)] = []
+        let stepInterval = 5
+
+        // Positive direction
+        var step = stepInterval
+        while true {
+            let offset = CGFloat(step) * stepPixels
+            if offset > positiveMax { break }
+            result.append((offset, step))
+            step += stepInterval
+        }
+
+        // Negative direction
+        step = stepInterval
+        while true {
+            let offset = -CGFloat(step) * stepPixels
+            if -offset > negativeMax { break }
+            result.append((offset, step))
+            step += stepInterval
+        }
+
+        return result
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        drawCrosshair()
+        drawGuideLines()
+        drawModeIndicator()
+    }
+
+    private func drawCrosshair() {
+        let path = NSBezierPath()
+        NSColor.systemGreen.withAlphaComponent(CursorViewLayout.crosshairAlpha).setStroke()
+        path.lineWidth = CursorViewLayout.crosshairWidth
+
+        // Horizontal line
+        path.move(to: CGPoint(x: 0, y: cursorPosition.y))
+        path.line(to: CGPoint(x: bounds.width, y: cursorPosition.y))
+
+        // Vertical line
+        path.move(to: CGPoint(x: cursorPosition.x, y: 0))
+        path.line(to: CGPoint(x: cursorPosition.x, y: bounds.height))
+
+        path.stroke()
+    }
+
+    private func drawGuideLines() {
+        let stepPixels = CGFloat(settings.cursorStepPixels)
+
+        // Horizontal guide lines (for vertical movement: j/k)
+        let hOffsets = CursorView.guideLineOffsets(
+            origin: cursorPosition.y,
+            stepPixels: stepPixels,
+            positiveMax: bounds.height - cursorPosition.y,
+            negativeMax: cursorPosition.y
+        )
+        for (offset, stepCount) in hOffsets {
+            let y = cursorPosition.y + offset
+            drawHorizontalGuideLine(y: y, label: "\(stepCount)")
+        }
+
+        // Vertical guide lines (for horizontal movement: h/l)
+        let vOffsets = CursorView.guideLineOffsets(
+            origin: cursorPosition.x,
+            stepPixels: stepPixels,
+            positiveMax: bounds.width - cursorPosition.x,
+            negativeMax: cursorPosition.x
+        )
+        for (offset, stepCount) in vOffsets {
+            let x = cursorPosition.x + offset
+            drawVerticalGuideLine(x: x, label: "\(stepCount)")
+        }
+    }
+
+    private func drawHorizontalGuideLine(y: CGFloat, label: String) {
+        let path = NSBezierPath()
+        NSColor.systemGreen.withAlphaComponent(CursorViewLayout.guideLineAlpha).setStroke()
+        path.lineWidth = CursorViewLayout.guideLineWidth
+        path.move(to: CGPoint(x: 0, y: y))
+        path.line(to: CGPoint(x: bounds.width, y: y))
+        path.stroke()
+
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.monospacedSystemFont(ofSize: CursorViewLayout.labelFontSize, weight: .medium),
+            .foregroundColor: NSColor.systemGreen.withAlphaComponent(CursorViewLayout.labelAlpha)
+        ]
+        (label as NSString).draw(
+            at: CGPoint(x: cursorPosition.x + CursorViewLayout.labelOffsetX, y: y + CursorViewLayout.labelOffsetY),
+            withAttributes: attrs
+        )
+    }
+
+    private func drawVerticalGuideLine(x: CGFloat, label: String) {
+        let path = NSBezierPath()
+        NSColor.systemGreen.withAlphaComponent(CursorViewLayout.guideLineAlpha).setStroke()
+        path.lineWidth = CursorViewLayout.guideLineWidth
+        path.move(to: CGPoint(x: x, y: 0))
+        path.line(to: CGPoint(x: x, y: bounds.height))
+        path.stroke()
+
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.monospacedSystemFont(ofSize: CursorViewLayout.labelFontSize, weight: .medium),
+            .foregroundColor: NSColor.systemGreen.withAlphaComponent(CursorViewLayout.labelAlpha)
+        ]
+        (label as NSString).draw(
+            at: CGPoint(
+                x: x + CursorViewLayout.verticalLabelOffsetX,
+                y: cursorPosition.y + CursorViewLayout.verticalLabelOffsetY
+            ),
+            withAttributes: attrs
+        )
+    }
+
+    private func drawModeIndicator() {
+        let text = "CURSOR"
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: CursorViewLayout.indicatorFontSize, weight: .bold),
+            .foregroundColor: NSColor.systemGreen
+        ]
+        let size = (text as NSString).size(withAttributes: attrs)
+        let padding = CursorViewLayout.indicatorPadding
+        let boxWidth = size.width + padding * 2
+        let boxHeight = size.height + padding * 2
+        let margin = CursorViewLayout.indicatorMargin
+        let x = bounds.width - boxWidth - margin
+        let y = bounds.height - boxHeight - margin
+        let boxRect = CGRect(x: x, y: y, width: boxWidth, height: boxHeight)
+
+        let bgPath = NSBezierPath(
+            roundedRect: boxRect,
+            xRadius: CursorViewLayout.indicatorCornerRadius,
+            yRadius: CursorViewLayout.indicatorCornerRadius
+        )
+        NSColor.black.withAlphaComponent(CursorViewLayout.indicatorBgAlpha).setFill()
+        bgPath.fill()
+        NSColor.systemGreen.setStroke()
+        bgPath.lineWidth = CursorViewLayout.indicatorBorderWidth
+        bgPath.stroke()
+
+        (text as NSString).draw(at: CGPoint(x: x + padding, y: y + padding), withAttributes: attrs)
+    }
+}

--- a/Sources/Vimursor/HotkeyManager.swift
+++ b/Sources/Vimursor/HotkeyManager.swift
@@ -7,6 +7,7 @@ final class HotkeyManager: @unchecked Sendable {
     var onHintModeActivated: (() -> Void)?
     var onSearchModeActivated: (() -> Void)?
     var onScrollModeActivated: (() -> Void)?
+    var onCursorModeActivated: (() -> Void)?
 
     // CGEventTap スレッド（読み取り）とメインスレッド（書き込み）をまたぐため NSLock で保護
     private let handlerLock = NSLock()

--- a/Sources/Vimursor/Settings/AppSettings.swift
+++ b/Sources/Vimursor/Settings/AppSettings.swift
@@ -24,6 +24,7 @@ enum AppSettingsKey {
     static let isContinuousMode = "hintMode.continuousMode"  // 既存キーと互換
     static let reactivationDelay = "behavior.reactivationDelay"
     static let scrollStepLines = "behavior.scrollStepLines"
+    static let cursorStepPixels = "behavior.cursorStepPixels"
 }
 
 // MARK: - AppSettings
@@ -45,6 +46,7 @@ final class AppSettings: @unchecked Sendable {
         static let isContinuousMode: Bool = false
         static let reactivationDelay: TimeInterval = 0.3
         static let scrollStepLines: Int = 3
+        static let cursorStepPixels: Int = 5
     }
 
     // MARK: - Storage
@@ -67,7 +69,8 @@ final class AppSettings: @unchecked Sendable {
             AppSettingsKey.hintCharacterSet: Defaults.hintCharacterSet,
             AppSettingsKey.isContinuousMode: Defaults.isContinuousMode,
             AppSettingsKey.reactivationDelay: Defaults.reactivationDelay,
-            AppSettingsKey.scrollStepLines: Defaults.scrollStepLines
+            AppSettingsKey.scrollStepLines: Defaults.scrollStepLines,
+            AppSettingsKey.cursorStepPixels: Defaults.cursorStepPixels
         ])
     }
 
@@ -132,6 +135,11 @@ final class AppSettings: @unchecked Sendable {
         set { defaults.set(newValue, forKey: AppSettingsKey.scrollStepLines) }
     }
 
+    var cursorStepPixels: Int {
+        get { defaults.integer(forKey: AppSettingsKey.cursorStepPixels) }
+        set { defaults.set(newValue, forKey: AppSettingsKey.cursorStepPixels) }
+    }
+
     // MARK: - Reset
 
     /// 全設定をデフォルト値にリセットする。
@@ -146,7 +154,8 @@ final class AppSettings: @unchecked Sendable {
             AppSettingsKey.hintCharacterSet,
             AppSettingsKey.isContinuousMode,
             AppSettingsKey.reactivationDelay,
-            AppSettingsKey.scrollStepLines
+            AppSettingsKey.scrollStepLines,
+            AppSettingsKey.cursorStepPixels
         ]
         for key in keys {
             defaults.removeObject(forKey: key)

--- a/Sources/Vimursor/Settings/BehaviorSettingsView.swift
+++ b/Sources/Vimursor/Settings/BehaviorSettingsView.swift
@@ -29,6 +29,8 @@ final class BehaviorSettingsView: NSView {
     private let reactivationDelayStepper = NSStepper()
     private let scrollStepField = NSTextField()
     private let scrollStepStepper = NSStepper()
+    private let cursorStepField = NSTextField()
+    private let cursorStepStepper = NSStepper()
 
     // MARK: - Initialization
 
@@ -84,6 +86,19 @@ final class BehaviorSettingsView: NSView {
         scrollStepStepper.doubleValue = Double(settings.scrollStepLines)
         scrollStepStepper.target = self
         scrollStepStepper.action = #selector(scrollStepChanged(_:))
+
+        // Cursor Step Pixels
+        cursorStepField.stringValue = "\(settings.cursorStepPixels)"
+        cursorStepField.isEditable = false
+        cursorStepField.isBordered = true
+        cursorStepField.alignment = .right
+
+        cursorStepStepper.minValue = 1
+        cursorStepStepper.maxValue = 100
+        cursorStepStepper.increment = 1
+        cursorStepStepper.doubleValue = Double(settings.cursorStepPixels)
+        cursorStepStepper.target = self
+        cursorStepStepper.action = #selector(cursorStepChanged(_:))
     }
 
     private func setupLayout() {
@@ -92,7 +107,8 @@ final class BehaviorSettingsView: NSView {
             ("Hint Characters:", [hintCharSetField]),
             ("Continuous Hint Mode:", [continuousModeCheckbox]),
             ("Reactivation Delay (s):", [reactivationDelayField, reactivationDelayStepper]),
-            ("Scroll Step Lines:", [scrollStepField, scrollStepStepper])
+            ("Scroll Step Lines:", [scrollStepField, scrollStepStepper]),
+            ("Cursor Step (px):", [cursorStepField, cursorStepStepper])
         ]
 
         for (index, row) in rows.enumerated() {
@@ -184,6 +200,12 @@ final class BehaviorSettingsView: NSView {
         settings.scrollStepLines = value
     }
 
+    @objc private func cursorStepChanged(_ sender: NSStepper) {
+        let value = Int(sender.doubleValue)
+        cursorStepField.stringValue = "\(value)"
+        settings.cursorStepPixels = value
+    }
+
     // MARK: - Public
 
     /// 設定の現在値をコントロールに反映する（Reset 後などに使用）。
@@ -195,6 +217,8 @@ final class BehaviorSettingsView: NSView {
         reactivationDelayField.stringValue = String(format: "%.1f", settings.reactivationDelay)
         scrollStepStepper.doubleValue = Double(settings.scrollStepLines)
         scrollStepField.stringValue = "\(settings.scrollStepLines)"
+        cursorStepStepper.doubleValue = Double(settings.cursorStepPixels)
+        cursorStepField.stringValue = "\(settings.cursorStepPixels)"
     }
 }
 

--- a/Sources/Vimursor/Settings/BehaviorSettingsView.swift
+++ b/Sources/Vimursor/Settings/BehaviorSettingsView.swift
@@ -102,7 +102,6 @@ final class BehaviorSettingsView: NSView {
     }
 
     private func setupLayout() {
-        // 各行: (ラベルテキスト, コントロール群)
         let rows: [(String, [NSView])] = [
             ("Hint Characters:", [hintCharSetField]),
             ("Continuous Hint Mode:", [continuousModeCheckbox]),
@@ -112,52 +111,54 @@ final class BehaviorSettingsView: NSView {
         ]
 
         for (index, row) in rows.enumerated() {
-            let label = makeLabel(row.0)
-            label.translatesAutoresizingMaskIntoConstraints = false
-            addSubview(label)
-
             let yOffset = Layout.margin + CGFloat(rows.count - 1 - index) * (Layout.rowHeight + Layout.rowSpacing)
+            addLabeledRow(title: row.0, controls: row.1, yOffset: yOffset)
+        }
+    }
 
+    private func addLabeledRow(title: String, controls: [NSView], yOffset: CGFloat) {
+        let label = makeLabel(title)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(label)
+
+        let centerY = yOffset + Layout.rowHeight / 2
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Layout.margin),
+            label.widthAnchor.constraint(equalToConstant: Layout.labelWidth),
+            label.centerYAnchor.constraint(equalTo: topAnchor, constant: centerY)
+        ])
+
+        var xOffset = Layout.margin + Layout.labelWidth + 8
+        for control in controls {
+            control.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(control)
+            xOffset += layoutControl(control, xOffset: xOffset, centerY: centerY)
+        }
+    }
+
+    private func layoutControl(_ control: NSView, xOffset: CGFloat, centerY: CGFloat) -> CGFloat {
+        switch control {
+        case let stepper as NSStepper:
             NSLayoutConstraint.activate([
-                label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Layout.margin),
-                label.widthAnchor.constraint(equalToConstant: Layout.labelWidth),
-                label.centerYAnchor.constraint(equalTo: topAnchor, constant: yOffset + Layout.rowHeight / 2)
+                stepper.leadingAnchor.constraint(equalTo: leadingAnchor, constant: xOffset),
+                stepper.widthAnchor.constraint(equalToConstant: Layout.stepperWidth),
+                stepper.centerYAnchor.constraint(equalTo: topAnchor, constant: centerY)
             ])
-
-            var xOffset = Layout.margin + Layout.labelWidth + 8
-            for control in row.1 {
-                control.translatesAutoresizingMaskIntoConstraints = false
-                addSubview(control)
-
-                switch control {
-                case let stepper as NSStepper:
-                    NSLayoutConstraint.activate([
-                        stepper.leadingAnchor.constraint(equalTo: leadingAnchor, constant: xOffset),
-                        stepper.widthAnchor.constraint(equalToConstant: Layout.stepperWidth),
-                        stepper.centerYAnchor.constraint(
-                            equalTo: topAnchor, constant: yOffset + Layout.rowHeight / 2
-                        )
-                    ])
-                    xOffset += Layout.stepperWidth + 4
-                case let button as NSButton:
-                    NSLayoutConstraint.activate([
-                        button.leadingAnchor.constraint(equalTo: leadingAnchor, constant: xOffset),
-                        button.centerYAnchor.constraint(
-                            equalTo: topAnchor, constant: yOffset + Layout.rowHeight / 2
-                        )
-                    ])
-                default:
-                    let fieldWidth: CGFloat = control === hintCharSetField ? 160 : Layout.valueFieldWidth
-                    NSLayoutConstraint.activate([
-                        control.leadingAnchor.constraint(equalTo: leadingAnchor, constant: xOffset),
-                        control.widthAnchor.constraint(equalToConstant: fieldWidth),
-                        control.centerYAnchor.constraint(
-                            equalTo: topAnchor, constant: yOffset + Layout.rowHeight / 2
-                        )
-                    ])
-                    xOffset += fieldWidth + 4
-                }
-            }
+            return Layout.stepperWidth + 4
+        case let button as NSButton:
+            NSLayoutConstraint.activate([
+                button.leadingAnchor.constraint(equalTo: leadingAnchor, constant: xOffset),
+                button.centerYAnchor.constraint(equalTo: topAnchor, constant: centerY)
+            ])
+            return 0
+        default:
+            let fieldWidth: CGFloat = control === hintCharSetField ? 160 : Layout.valueFieldWidth
+            NSLayoutConstraint.activate([
+                control.leadingAnchor.constraint(equalTo: leadingAnchor, constant: xOffset),
+                control.widthAnchor.constraint(equalToConstant: fieldWidth),
+                control.centerYAnchor.constraint(equalTo: topAnchor, constant: centerY)
+            ])
+            return fieldWidth + 4
         }
     }
 

--- a/Sources/Vimursor/Settings/ShortcutNames.swift
+++ b/Sources/Vimursor/Settings/ShortcutNames.swift
@@ -23,4 +23,10 @@ extension KeyboardShortcuts.Name {
         "scrollMode",
         default: .init(.j, modifiers: [.command, .shift])
     )
+
+    /// カーソルモード起動ショートカット（デフォルト: Cmd+Shift+K）
+    nonisolated(unsafe) static let cursorMode = Self(
+        "cursorMode",
+        default: .init(.k, modifiers: [.command, .shift])
+    )
 }

--- a/Sources/Vimursor/Settings/ShortcutsSettingsView.swift
+++ b/Sources/Vimursor/Settings/ShortcutsSettingsView.swift
@@ -23,6 +23,7 @@ final class ShortcutsSettingsView: NSView {
     private let hintModeRecorder = ShortcutRecorderField(for: .hintMode)
     private let searchModeRecorder = ShortcutRecorderField(for: .searchMode)
     private let scrollModeRecorder = ShortcutRecorderField(for: .scrollMode)
+    private let cursorModeRecorder = ShortcutRecorderField(for: .cursorMode)
 
     // MARK: - Initialization
 
@@ -40,7 +41,8 @@ final class ShortcutsSettingsView: NSView {
         let rows: [(String, ShortcutRecorderField)] = [
             ("Hint Mode:", hintModeRecorder),
             ("Search Mode:", searchModeRecorder),
-            ("Scroll Mode:", scrollModeRecorder)
+            ("Scroll Mode:", scrollModeRecorder),
+            ("Cursor Mode:", cursorModeRecorder)
         ]
 
         for (index, (labelText, recorder)) in rows.enumerated() {

--- a/Sources/Vimursor/StatusBarController.swift
+++ b/Sources/Vimursor/StatusBarController.swift
@@ -9,6 +9,7 @@ private enum MenuItemTag {
     static let hintMode = 102
     static let searchMode = 103
     static let scrollMode = 104
+    static let cursorMode = 105
 }
 
 // MARK: - Protocol
@@ -53,6 +54,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     private let onHintMode: () -> Void
     private let onSearchMode: () -> Void
     private let onScrollMode: () -> Void
+    private let onCursorMode: () -> Void
     private let onSettings: (() -> Void)?
     private let loginItemManager: LoginItemManager?
     private let settings: AppSettings
@@ -64,6 +66,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         onHintMode: @escaping () -> Void,
         onSearchMode: @escaping () -> Void,
         onScrollMode: @escaping () -> Void,
+        onCursorMode: @escaping () -> Void = {},
         onSettings: (() -> Void)? = nil,
         loginItemManager: LoginItemManager? = nil,
         settings: AppSettings = .shared
@@ -73,6 +76,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
             onHintMode: onHintMode,
             onSearchMode: onSearchMode,
             onScrollMode: onScrollMode,
+            onCursorMode: onCursorMode,
             onSettings: onSettings,
             loginItemManager: loginItemManager,
             settings: settings
@@ -85,6 +89,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         onHintMode: @escaping () -> Void,
         onSearchMode: @escaping () -> Void,
         onScrollMode: @escaping () -> Void,
+        onCursorMode: @escaping () -> Void = {},
         onSettings: (() -> Void)? = nil,
         loginItemManager: LoginItemManager? = nil,
         settings: AppSettings = .shared
@@ -93,6 +98,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         self.onHintMode = onHintMode
         self.onSearchMode = onSearchMode
         self.onScrollMode = onScrollMode
+        self.onCursorMode = onCursorMode
         self.onSettings = onSettings
         self.loginItemManager = loginItemManager
         self.settings = settings
@@ -154,6 +160,16 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         scrollItem.tag = MenuItemTag.scrollMode
         scrollItem.setShortcut(for: .scrollMode)
         menu.addItem(scrollItem)
+
+        let cursorItem = NSMenuItem(
+            title: "Cursor Mode",
+            action: #selector(activateCursorMode),
+            keyEquivalent: ""
+        )
+        cursorItem.target = self
+        cursorItem.tag = MenuItemTag.cursorMode
+        cursorItem.setShortcut(for: .cursorMode)
+        menu.addItem(cursorItem)
     }
 
     private func addAppItems(to menu: NSMenu) {
@@ -211,7 +227,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
     func menuWillOpen(_ menu: NSMenu) {
         // メニューが開いている間は Carbon ホットキーをバッファしないよう無効化する
-        KeyboardShortcuts.disable(.hintMode, .searchMode, .scrollMode)
+        KeyboardShortcuts.disable(.hintMode, .searchMode, .scrollMode, .cursorMode)
 
         // macOS のメニュー描画エンジンは Shift+記号キー（例: Shift+/）の表示を正しく描画できない。
         // setShortcut(for:) が "/" + [.command, .shift] を設定するため、
@@ -241,7 +257,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     }
 
     func menuDidClose(_ menu: NSMenu) {
-        KeyboardShortcuts.enable(.hintMode, .searchMode, .scrollMode)
+        KeyboardShortcuts.enable(.hintMode, .searchMode, .scrollMode, .cursorMode)
     }
 
     // MARK: - Menu actions
@@ -256,6 +272,10 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
     @objc private func activateScrollMode() {
         onScrollMode()
+    }
+
+    @objc private func activateCursorMode() {
+        onCursorMode()
     }
 
     @objc private func openSettings() {
@@ -291,6 +311,10 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
     func simulateScrollMode() {
         onScrollMode()
+    }
+
+    func simulateCursorMode() {
+        onCursorMode()
     }
 
     func simulateSettings() {

--- a/Tests/VimursorTests/CursorEngineTests.swift
+++ b/Tests/VimursorTests/CursorEngineTests.swift
@@ -1,0 +1,106 @@
+import Testing
+import CoreGraphics
+@testable import Vimursor
+
+@Suite("CursorEngine Tests")
+struct CursorEngineTests {
+    let screenBounds = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+
+    // MARK: - moveCursor
+
+    @Test("右移動")
+    func moveRight() {
+        let result = CursorEngine.moveCursor(
+            from: CGPoint(x: 100, y: 100),
+            direction: .right, steps: 1, stepPixels: 20, screenBounds: screenBounds
+        )
+        #expect(result.x == 120)
+        #expect(result.y == 100)
+    }
+
+    @Test("左移動")
+    func moveLeft() {
+        let result = CursorEngine.moveCursor(
+            from: CGPoint(x: 100, y: 100),
+            direction: .left, steps: 1, stepPixels: 20, screenBounds: screenBounds
+        )
+        #expect(result.x == 80)
+        #expect(result.y == 100)
+    }
+
+    @Test("上移動（スクリーン座標: y減少）")
+    func moveUp() {
+        let result = CursorEngine.moveCursor(
+            from: CGPoint(x: 100, y: 100),
+            direction: .up, steps: 1, stepPixels: 20, screenBounds: screenBounds
+        )
+        #expect(result.x == 100)
+        #expect(result.y == 80)
+    }
+
+    @Test("下移動（スクリーン座標: y増加）")
+    func moveDown() {
+        let result = CursorEngine.moveCursor(
+            from: CGPoint(x: 100, y: 100),
+            direction: .down, steps: 1, stepPixels: 20, screenBounds: screenBounds
+        )
+        #expect(result.x == 100)
+        #expect(result.y == 120)
+    }
+
+    @Test("マルチプライヤ: 5ステップ")
+    func moveWithMultiplier() {
+        let result = CursorEngine.moveCursor(
+            from: CGPoint(x: 100, y: 100),
+            direction: .right, steps: 5, stepPixels: 20, screenBounds: screenBounds
+        )
+        #expect(result.x == 200)
+    }
+
+    @Test("右端クランプ")
+    func clampRight() {
+        let result = CursorEngine.moveCursor(
+            from: CGPoint(x: 1900, y: 100),
+            direction: .right, steps: 5, stepPixels: 20, screenBounds: screenBounds
+        )
+        #expect(result.x == 1920)
+    }
+
+    @Test("左端クランプ")
+    func clampLeft() {
+        let result = CursorEngine.moveCursor(
+            from: CGPoint(x: 10, y: 100),
+            direction: .left, steps: 5, stepPixels: 20, screenBounds: screenBounds
+        )
+        #expect(result.x == 0)
+    }
+
+    @Test("上端クランプ")
+    func clampTop() {
+        let result = CursorEngine.moveCursor(
+            from: CGPoint(x: 100, y: 10),
+            direction: .up, steps: 5, stepPixels: 20, screenBounds: screenBounds
+        )
+        #expect(result.y == 0)
+    }
+
+    @Test("下端クランプ")
+    func clampBottom() {
+        let result = CursorEngine.moveCursor(
+            from: CGPoint(x: 100, y: 1070),
+            direction: .down, steps: 5, stepPixels: 20, screenBounds: screenBounds
+        )
+        #expect(result.y == 1080)
+    }
+
+    // MARK: - screenPointFromMouseLocation
+
+    @Test("NSEvent座標 → スクリーン座標変換")
+    func convertMouseLocation() {
+        let result = CursorEngine.screenPointFromMouseLocation(
+            CGPoint(x: 100, y: 200), screenHeight: 1080
+        )
+        #expect(result.x == 100)
+        #expect(result.y == 880)
+    }
+}

--- a/Tests/VimursorTests/CursorModeControllerTests.swift
+++ b/Tests/VimursorTests/CursorModeControllerTests.swift
@@ -1,0 +1,24 @@
+import Testing
+import CoreGraphics
+@testable import Vimursor
+
+@Suite("CursorModeController Tests")
+struct CursorModeControllerTests {
+
+    @Test("parseMultiplier: 空文字列は 1 を返す")
+    func parseMultiplierEmpty() {
+        #expect(CursorModeController.parseMultiplier("") == 1)
+    }
+
+    @Test("parseMultiplier: 数字文字列をパースする")
+    func parseMultiplierNumber() {
+        #expect(CursorModeController.parseMultiplier("5") == 5)
+        #expect(CursorModeController.parseMultiplier("12") == 12)
+        #expect(CursorModeController.parseMultiplier("99") == 99)
+    }
+
+    @Test("parseMultiplier: 不正な文字列は 1 を返す")
+    func parseMultiplierInvalid() {
+        #expect(CursorModeController.parseMultiplier("abc") == 1)
+    }
+}

--- a/Tests/VimursorTests/CursorViewTests.swift
+++ b/Tests/VimursorTests/CursorViewTests.swift
@@ -1,0 +1,63 @@
+import Testing
+@testable import Vimursor
+
+@Suite("CursorView Tests")
+struct CursorViewTests {
+
+    @Test("正方向のガイドライン: 5ステップ間隔で生成される")
+    func positiveGuideLines() {
+        let offsets = CursorView.guideLineOffsets(
+            origin: 500, stepPixels: 20, positiveMax: 300, negativeMax: 500
+        )
+        let positiveSteps = offsets.filter { $0.offset > 0 }.map { $0.stepCount }
+        // 300px / 20px = 15 steps max, so 5, 10, 15
+        #expect(positiveSteps.contains(5))
+        #expect(positiveSteps.contains(10))
+        #expect(positiveSteps.contains(15))
+        #expect(!positiveSteps.contains(20))  // 20*20=400 > 300
+    }
+
+    @Test("負方向のガイドライン")
+    func negativeGuideLines() {
+        let offsets = CursorView.guideLineOffsets(
+            origin: 200, stepPixels: 20, positiveMax: 800, negativeMax: 200
+        )
+        let negativeSteps = offsets.filter { $0.offset < 0 }.map { $0.stepCount }
+        // 200px / 20px = 10 steps max, so 5, 10
+        #expect(negativeSteps.contains(5))
+        #expect(negativeSteps.contains(10))
+        #expect(!negativeSteps.contains(15))  // 15*20=300 > 200
+    }
+
+    @Test("stepPixels が 0 の場合は空配列")
+    func zeroStepPixels() {
+        let offsets = CursorView.guideLineOffsets(
+            origin: 500, stepPixels: 0, positiveMax: 500, negativeMax: 500
+        )
+        #expect(offsets.isEmpty)
+    }
+
+    @Test("画面端に近い場合: ガイドラインが少ない")
+    func nearEdge() {
+        let offsets = CursorView.guideLineOffsets(
+            origin: 50, stepPixels: 20, positiveMax: 950, negativeMax: 50
+        )
+        let negativeSteps = offsets.filter { $0.offset < 0 }.map { $0.stepCount }
+        // 50px / 20px = 2.5 → no 5-step line fits
+        #expect(negativeSteps.isEmpty)
+    }
+
+    @Test("オフセットの値が正しい")
+    func correctOffsetValues() {
+        let offsets = CursorView.guideLineOffsets(
+            origin: 500, stepPixels: 10, positiveMax: 200, negativeMax: 200
+        )
+        let positive = offsets.filter { $0.offset > 0 }.sorted { $0.stepCount < $1.stepCount }
+        // stepPixels=10, so 5 steps = 50px, 10 steps = 100px, 15 steps = 150px, 20 steps = 200px
+        #expect(positive.count == 4)
+        #expect(positive[0].offset == 50)
+        #expect(positive[0].stepCount == 5)
+        #expect(positive[1].offset == 100)
+        #expect(positive[1].stepCount == 10)
+    }
+}

--- a/Tests/VimursorTests/StatusBarControllerTests.swift
+++ b/Tests/VimursorTests/StatusBarControllerTests.swift
@@ -83,6 +83,26 @@ struct StatusBarControllerTests {
         #expect(scrollCalled == true)
     }
 
+    @Test("onCursorMode クロージャが呼ばれること")
+    @MainActor
+    func cursorModeCallbackIsInvoked() {
+        var cursorCalled = false
+        var otherCalled = false
+
+        let controller = StatusBarController(
+            statusItem: MockStatusItem(),
+            onHintMode: { otherCalled = true },
+            onSearchMode: { otherCalled = true },
+            onScrollMode: { otherCalled = true },
+            onCursorMode: { cursorCalled = true },
+            settings: makeSettings()
+        )
+
+        controller.simulateCursorMode()
+        #expect(cursorCalled == true)
+        #expect(otherCalled == false)
+    }
+
     @Test("onSettings クロージャが呼ばれること")
     @MainActor
     func settingsCallbackIsInvoked() {
@@ -110,9 +130,9 @@ struct StatusBarControllerTests {
             onScrollMode: {},
             settings: makeSettings()
         )
-        // Hint Mode, Search Mode, Scroll Mode, separator, Settings..., About, separator,
-        // Continuous Hint Mode, Launch at Login, separator, Quit = 11 items
-        #expect(mockItem.menu?.items.count == 11)
+        // Hint Mode, Search Mode, Scroll Mode, Cursor Mode, separator, Settings..., About, separator,
+        // Continuous Hint Mode, Launch at Login, separator, Quit = 12 items
+        #expect(mockItem.menu?.items.count == 12)
     }
 
     @Test("メニューに Continuous Hint Mode 項目が含まれること")
@@ -145,6 +165,7 @@ struct StatusBarControllerTests {
         #expect(titles.contains("Hint Mode"))
         #expect(titles.contains("Search Mode"))
         #expect(titles.contains("Scroll Mode"))
+        #expect(titles.contains("Cursor Mode"))
         #expect(titles.contains("Settings..."))
         #expect(titles.contains("About Vimursor"))
         #expect(titles.contains("Launch at Login"))


### PR DESCRIPTION
## Summary

- hjkl でマウスカーソルをピクセル単位で移動するカーソル移動モードを追加
- 数値プレフィクス（`5j`, `10k` 等）で倍率指定
- 起動時にカーソル位置を中心に5ステップ間隔のクロスヘアガイドラインを表示
- `Enter` で左クリック、`Shift+Enter` で右クリック、`ESC` で終了
- 設定画面から stepPixels を変更可能（デフォルト: 5px）
- ショートカット設定画面に Cursor Mode を追加
- メニューバーに Cursor Mode 項目を追加

| キー | アクション |
|------|-----------|
| h/j/k/l | 左/下/上/右に移動 |
| 数字 + hjkl | N ステップ移動（例: `5j`） |
| Enter | 左クリック |
| Shift+Enter | 右クリック |
| ESC | モード終了 |

Epic: #134
Closes #134, Closes #135, Closes #136, Closes #137, Closes #138

## Test plan

- [x] Cmd+Shift+K でカーソル移動モードが起動する
- [x] hjkl でカーソルが移動する
- [x] 数値プレフィクス（5j 等）で倍率指定できる
- [x] ガイドラインが5ステップ間隔で表示される
- [x] カーソル移動に追従してガイドラインが再描画される
- [x] Enter で左クリック、Shift+Enter で右クリック
- [x] ESC でモード終了
- [x] 設定画面で stepPixels を変更できる
- [x] `swift test` — 196 テスト全通過