### PR TITLE
chore: Replace Discussions with Issue-based feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_feature.yml
+++ b/.github/ISSUE_TEMPLATE/2_feature.yml
@@ -1,0 +1,18 @@
+name: Feature Request
+description: Suggest a new feature or improvement.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the feature you'd like.
+    validations:
+      required: true
+  - type: textarea
+    id: use-cases
+    attributes:
+      label: Use Cases
+      description: How would you use this feature?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
 blank_issues_enabled: false
-contact_links:
-  - name: Feature Request
-    url: https://github.com/kodakoda-koda/Vimursor/discussions/new?category=ideas
-    about: Suggest a new feature or improvement in Discussions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ Sources/Vimursor/
 ## Reporting Issues
 
 - **Bugs**: Use the [Bug Report](https://github.com/kodakoda-koda/Vimursor/issues/new/choose) template
-- **Feature ideas**: Open a [Discussion](https://github.com/kodakoda-koda/Vimursor/discussions/new?category=ideas)
+- **Feature ideas**: Open a [Feature Request](https://github.com/kodakoda-koda/Vimursor/issues/new?template=2_feature.yml)
 
 ---
 


### PR DESCRIPTION
## Summary

- Add Feature Request issue template (`2_feature.yml`)
- Remove Discussion redirect from `config.yml` (keep `blank_issues_enabled: false`)
- Update CONTRIBUTING.md to link to Issue template instead of Discussions

## Test plan

- [ ] "New Issue" shows Feature Request template in the list
- [ ] Blank issues are still disabled
- [ ] CONTRIBUTING.md link opens the correct template