### PR TITLE
fix: スクロールモード誤検出を修正

### DIFF
--- a/Sources/Vimursor/Accessibility/AXManager.swift
+++ b/Sources/Vimursor/Accessibility/AXManager.swift
@@ -170,11 +170,22 @@ final class AXManager: @unchecked Sendable {
     ) {
         let appElement = AXElement(ref: app)
         DispatchQueue.global(qos: .userInitiated).async {
-            let areas = ScrollTarget.enumerateScrollableElements(root: appElement.ref)
+            let windowFrame = Self.focusedWindowFrame(of: appElement.ref)
+            let areas = ScrollTarget.enumerateScrollableElements(root: appElement.ref, windowFrame: windowFrame)
             DispatchQueue.main.async {
                 completion(areas)
             }
         }
+    }
+
+    /// フォーカスウィンドウのフレームを AX スクリーン座標（原点:左上）で返す。
+    /// 取得できない場合は nil を返す（フィルタリングをスキップするため）。
+    private static func focusedWindowFrame(of app: AXUIElement) -> CGRect? {
+        var windowRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(app, "AXFocusedWindow" as CFString, &windowRef) == .success,
+              let windowRef,
+              let window = AXAttributes.element(from: windowRef) else { return nil }
+        return AXAttributes.frame(of: window)
     }
 
     private func fetchFrame(element: AXUIElement, screenHeight: CGFloat) -> CGRect? {

--- a/Sources/Vimursor/ScrollMode/ScrollAreaFilter.swift
+++ b/Sources/Vimursor/ScrollMode/ScrollAreaFilter.swift
@@ -1,0 +1,108 @@
+import CoreGraphics
+
+/// スクロール領域をウィンドウ可視領域でフィルタリングし、重複を除去する純粋関数群。
+enum ScrollAreaFilter {
+
+    struct FilteredArea {
+        let frame: CGRect          // クリップ後のフレーム（スクリーン座標）
+        let originalFrame: CGRect  // クリップ前のフレーム
+        let originMoved: Bool      // クリップにより origin が移動したか
+    }
+
+    // MARK: - Constants
+
+    /// クリップ後の面積が元の面積に対して持つべき最小比率
+    private static let minVisibleAreaRatio: CGFloat = 0.5
+    /// クリップ後の幅または高さの最小値（ポイント）
+    private static let minDimensionPoints: CGFloat = 100
+    /// 重複とみなすオーバーラップ比率の閾値
+    private static let overlapThresholdRatio: CGFloat = 0.5
+
+    // MARK: - filterByWindow
+
+    /// スクロール領域をウィンドウの可視領域でフィルタリングする。
+    ///
+    /// 除外条件:
+    /// 1. 領域がウィンドウ全体を包含する（デスクトップレベルの領域）
+    /// 2. ウィンドウとの交差がない
+    /// 3. クリップ後の面積が元の面積の 50% 未満
+    /// 4. クリップ後の幅または高さが 100pt 未満
+    static func filterByWindow(
+        areas: [CGRect],
+        windowFrame: CGRect
+    ) -> [FilteredArea] {
+        areas.compactMap { areaFrame in
+            // 1. 領域がウィンドウ全体を包含する場合は除外
+            if areaFrame.contains(windowFrame) { return nil }
+
+            // 2. 交差がない場合は除外
+            let intersection = areaFrame.intersection(windowFrame)
+            if intersection.isNull { return nil }
+
+            // 3. クリップ後の面積が元の面積の minVisibleAreaRatio 未満は除外
+            let originalArea = areaFrame.width * areaFrame.height
+            let clippedArea = intersection.width * intersection.height
+            guard originalArea > 0, clippedArea / originalArea >= minVisibleAreaRatio else { return nil }
+
+            // 4. クリップ後のサイズが最小サイズ未満は除外
+            guard intersection.width >= minDimensionPoints,
+                  intersection.height >= minDimensionPoints else { return nil }
+
+            let originMoved = intersection.origin != areaFrame.origin
+            return FilteredArea(
+                frame: intersection,
+                originalFrame: areaFrame,
+                originMoved: originMoved
+            )
+        }
+    }
+
+    // MARK: - removeOverlaps
+
+    /// 重複するスクロール領域を除去する。
+    ///
+    /// ペア (i, j) で 50% 超の重複がある場合:
+    /// - どちらか一方のみ originMoved=true → その要素を除外（隠れている可能性が高い）
+    /// - 両方とも同じ originMoved 値 → 小さい方を除外
+    static func removeOverlaps(areas: [FilteredArea]) -> [FilteredArea] {
+        var excluded = Set<Int>()
+
+        for i in 0..<areas.count {
+            for j in (i + 1)..<areas.count {
+                guard !excluded.contains(i), !excluded.contains(j) else { continue }
+
+                let a = areas[i]
+                let b = areas[j]
+                let intersection = a.frame.intersection(b.frame)
+                if intersection.isNull { continue }
+
+                let intersectionArea = intersection.width * intersection.height
+                let areaA = a.frame.width * a.frame.height
+                let areaB = b.frame.width * b.frame.height
+
+                let overlapRatioA = areaA > 0 ? intersectionArea / areaA : 0
+                let overlapRatioB = areaB > 0 ? intersectionArea / areaB : 0
+
+                guard overlapRatioA > overlapThresholdRatio || overlapRatioB > overlapThresholdRatio else { continue }
+
+                // どちらか一方のみ originMoved → originMoved を除外
+                if a.originMoved && !b.originMoved {
+                    excluded.insert(i)
+                } else if !a.originMoved && b.originMoved {
+                    excluded.insert(j)
+                } else {
+                    // 両方同じ originMoved → 小さい方を除外
+                    if areaA <= areaB {
+                        excluded.insert(i)
+                    } else {
+                        excluded.insert(j)
+                    }
+                }
+            }
+        }
+
+        return areas.enumerated().compactMap { (index, area) in
+            excluded.contains(index) ? nil : area
+        }
+    }
+}

--- a/Sources/Vimursor/ScrollMode/ScrollAreaFilter.swift
+++ b/Sources/Vimursor/ScrollMode/ScrollAreaFilter.swift
@@ -17,6 +17,8 @@ enum ScrollAreaFilter {
     private static let minDimensionPoints: CGFloat = 100
     /// 重複とみなすオーバーラップ比率の閾値
     private static let overlapThresholdRatio: CGFloat = 0.5
+    /// デスクトップレベルの領域とみなす面積比率（ウィンドウ面積に対する倍率）
+    private static let desktopAreaRatio: CGFloat = 1.5
 
     // MARK: - filterByWindow
 
@@ -32,8 +34,11 @@ enum ScrollAreaFilter {
         windowFrame: CGRect
     ) -> [FilteredArea] {
         areas.compactMap { areaFrame in
-            // 1. 領域がウィンドウ全体を包含する場合は除外
-            if areaFrame.contains(windowFrame) { return nil }
+            // 1. デスクトップレベルの領域（ウィンドウより desktopAreaRatio 以上大きい）は除外
+            // ウィンドウと同サイズの正当なスクロール領域（Chrome のメインページ等）は除外しない
+            let areaSize = areaFrame.width * areaFrame.height
+            let windowSize = windowFrame.width * windowFrame.height
+            if areaFrame.contains(windowFrame), windowSize > 0, areaSize / windowSize > desktopAreaRatio { return nil }
 
             // 2. 交差がない場合は除外
             let intersection = areaFrame.intersection(windowFrame)
@@ -83,7 +88,7 @@ enum ScrollAreaFilter {
                 let overlapRatioA = areaA > 0 ? intersectionArea / areaA : 0
                 let overlapRatioB = areaB > 0 ? intersectionArea / areaB : 0
 
-                guard overlapRatioA > overlapThresholdRatio || overlapRatioB > overlapThresholdRatio else { continue }
+                guard overlapRatioA >= overlapThresholdRatio || overlapRatioB >= overlapThresholdRatio else { continue }
 
                 // どちらか一方のみ originMoved → originMoved を除外
                 if a.originMoved && !b.originMoved {

--- a/Sources/Vimursor/ScrollMode/ScrollTarget.swift
+++ b/Sources/Vimursor/ScrollMode/ScrollTarget.swift
@@ -55,10 +55,27 @@ enum ScrollTarget {
     /// AX ツリーを走査し、スクロール可能な全領域を返す
     /// - AXWebArea を検出したら WebAreaSplitDetector に委譲してレイアウト分割を検出する
     /// - 通常のスクロール可能ロールはリーフ優先で収集する
-    static func enumerateScrollableElements(root: AXUIElement) -> [ScrollAreaInfo] {
+    /// - windowFrame が指定された場合、ウィンドウ可視領域でフィルタリングし重複を除去する
+    static func enumerateScrollableElements(
+        root: AXUIElement,
+        windowFrame: CGRect? = nil
+    ) -> [ScrollAreaInfo] {
         var result: [ScrollAreaInfo] = []
         collectScrollable(element: root, into: &result, depth: 0)
-        return result
+
+        guard let windowFrame else { return result }
+
+        // ウィンドウ可視領域でフィルタリング
+        let filtered = ScrollAreaFilter.filterByWindow(areas: result.map { $0.frame }, windowFrame: windowFrame)
+        let deduped = ScrollAreaFilter.removeOverlaps(areas: filtered)
+
+        return deduped.enumerated().map { (index, area) in
+            ScrollAreaInfo(
+                frame: area.frame,
+                centerPoint: CGPoint(x: area.frame.midX, y: area.frame.midY),
+                label: String(index + 1)
+            )
+        }
     }
 
     private static func collectScrollable(

--- a/Sources/Vimursor/ScrollMode/WebAreaSplitDetector.swift
+++ b/Sources/Vimursor/ScrollMode/WebAreaSplitDetector.swift
@@ -24,11 +24,11 @@ enum WebAreaSplitDetector {
 
     /// タイル間の最大ギャップ（ポイント）
     private static let tilingMaxGap: CGFloat = 50
-    /// 各タイルの高さ（または幅）が最大タイルに対して持つべき最小比率
+    /// 各タイルの高さが最大タイルに対して持つべき最小比率
     private static let tilingSizeRatio: CGFloat = 0.5
-    /// タイルのY座標（水平）またはX座標（垂直）のスプレッド許容値（ポイント）
+    /// タイルのY座標スプレッド許容値（ポイント）
     private static let tilingPositionTolerance: CGFloat = 50
-    /// タイルの合計幅（または高さ）が親ディメンションに対して持つべき最小比率
+    /// タイルの合計幅が親幅に対して持つべき最小比率
     private static let tilingCoverageRatio: CGFloat = 0.7
 
     // MARK: - Public API
@@ -82,7 +82,7 @@ enum WebAreaSplitDetector {
 
         if nonWrappers.count >= 2 {
             let frames = nonWrappers.map { $0.frame }
-            // タイリング検証: 候補が水平または垂直グリッドを形成しない場合は分割しない
+            // タイリング検証: 候補が水平グリッドを形成しない場合は分割しない
             guard validateTiling(candidates: frames, parentFrame: parentFrame) else {
                 return nil
             }

--- a/Sources/Vimursor/ScrollMode/WebAreaSplitDetector.swift
+++ b/Sources/Vimursor/ScrollMode/WebAreaSplitDetector.swift
@@ -20,6 +20,17 @@ enum WebAreaSplitDetector {
     /// この比率以上の幅を持つ子はラッパーとみなす（親幅に対する割合）
     static let wrapperWidthRatio: CGFloat = 0.9
 
+    // MARK: - Tiling Validation Constants
+
+    /// タイル間の最大ギャップ（ポイント）
+    private static let tilingMaxGap: CGFloat = 50
+    /// 各タイルの高さ（または幅）が最大タイルに対して持つべき最小比率
+    private static let tilingSizeRatio: CGFloat = 0.5
+    /// タイルのY座標（水平）またはX座標（垂直）のスプレッド許容値（ポイント）
+    private static let tilingPositionTolerance: CGFloat = 50
+    /// タイルの合計幅（または高さ）が親ディメンションに対して持つべき最小比率
+    private static let tilingCoverageRatio: CGFloat = 0.7
+
     // MARK: - Public API
 
     /// AXWebArea から ScrollAreaInfo のリストを返す。
@@ -70,8 +81,12 @@ enum WebAreaSplitDetector {
         }
 
         if nonWrappers.count >= 2 {
-            // 分割ポイント発見
-            return nonWrappers.map { $0.frame }
+            let frames = nonWrappers.map { $0.frame }
+            // タイリング検証: 候補が水平または垂直グリッドを形成しない場合は分割しない
+            guard validateTiling(candidates: frames, parentFrame: parentFrame) else {
+                return nil
+            }
+            return frames
         }
 
         // ラッパー（幅が wrapperWidthRatio 以上）の子を透過して再帰
@@ -86,6 +101,45 @@ enum WebAreaSplitDetector {
         }
 
         return nil
+    }
+
+    // MARK: - Tiling Validation
+
+    /// 候補フレームが水平タイリングパターンを形成するか検証する純粋関数。
+    /// 水平チェック: 候補がX軸方向に並んでいるか（Y位置スプレッドが小さい）。
+    /// 注: 垂直スタック（同幅要素の縦並び）はコンテンツセクションであり独立スクロール領域ではないため対象外。
+    // internal for testability
+    static func validateTiling(candidates: [CGRect], parentFrame: CGRect) -> Bool {
+        guard candidates.count >= 2 else { return false }
+        return checkHorizontalTiling(candidates: candidates, parentFrame: parentFrame)
+    }
+
+    /// 水平タイリング（候補がX軸方向に並ぶ）を検証する。
+    private static func checkHorizontalTiling(candidates: [CGRect], parentFrame: CGRect) -> Bool {
+        let sorted = candidates.sorted { $0.minX < $1.minX }
+        let maxHeight = sorted.map { $0.height }.max() ?? 0
+
+        // 隣接ギャップチェック（負のギャップ＝重複も無効）
+        for i in 0..<(sorted.count - 1) {
+            let gap = sorted[i + 1].minX - sorted[i].maxX
+            if gap < 0 || gap > tilingMaxGap { return false }
+        }
+
+        // Y位置スプレッドチェック
+        let minY = sorted.map { $0.minY }.min() ?? 0
+        let maxY = sorted.map { $0.minY }.max() ?? 0
+        if (maxY - minY) > tilingPositionTolerance { return false }
+
+        // サイズ比チェック（各候補の高さが最大高さに対して tilingSizeRatio 以上）
+        for rect in sorted {
+            if rect.height < maxHeight * tilingSizeRatio { return false }
+        }
+
+        // カバレッジチェック（合計幅が親幅に対して tilingCoverageRatio 以上）
+        let totalWidth = sorted.map { $0.width }.reduce(0, +)
+        if totalWidth < parentFrame.width * tilingCoverageRatio { return false }
+
+        return true
     }
 
     // MARK: - AX Tree Extraction

--- a/Sources/Vimursor/ScrollMode/WebAreaSplitDetector.swift
+++ b/Sources/Vimursor/ScrollMode/WebAreaSplitDetector.swift
@@ -105,9 +105,6 @@ enum WebAreaSplitDetector {
 
     // MARK: - Tiling Validation
 
-    /// 候補フレームが水平タイリングパターンを形成するか検証する純粋関数。
-    /// 水平チェック: 候補がX軸方向に並んでいるか（Y位置スプレッドが小さい）。
-    /// 注: 垂直スタック（同幅要素の縦並び）はコンテンツセクションであり独立スクロール領域ではないため対象外。
     // internal for testability
     static func validateTiling(candidates: [CGRect], parentFrame: CGRect) -> Bool {
         guard candidates.count >= 2 else { return false }
@@ -131,8 +128,8 @@ enum WebAreaSplitDetector {
         if (maxY - minY) > tilingPositionTolerance { return false }
 
         // サイズ比チェック（各候補の高さが最大高さに対して tilingSizeRatio 以上）
-        for rect in sorted {
-            if rect.height < maxHeight * tilingSizeRatio { return false }
+        for rect in sorted where rect.height < maxHeight * tilingSizeRatio {
+            return false
         }
 
         // カバレッジチェック（合計幅が親幅に対して tilingCoverageRatio 以上）

--- a/Tests/VimursorTests/ScrollAreaFilterTests.swift
+++ b/Tests/VimursorTests/ScrollAreaFilterTests.swift
@@ -10,10 +10,30 @@ struct ScrollAreaFilterTests {
     @Test("Area containing entire window is excluded (desktop-level area)")
     func areaContainingEntireWindowExcluded() {
         let windowFrame = CGRect(x: 100, y: 100, width: 800, height: 600)
-        // Area is larger than window and contains it
+        // Area is a full-screen desktop area: 2560x1440 >> window (800x600)
+        // ratio = 3686400 / 480000 ≈ 7.7 > desktopAreaRatio(1.5) → excluded
         let area = CGRect(x: 0, y: 0, width: 2560, height: 1440)
         let result = ScrollAreaFilter.filterByWindow(areas: [area], windowFrame: windowFrame)
         #expect(result.isEmpty)
+    }
+
+    @Test("Area equal to window frame is kept (Chrome-like main page scroll view)")
+    func areaEqualToWindowFrameIsKept() {
+        let windowFrame = CGRect(x: 0, y: 0, width: 1200, height: 900)
+        // Area exactly matches window frame — valid scroll area (e.g. Chrome main page)
+        // ratio = 1.0 <= desktopAreaRatio(1.5) → not excluded by desktop check
+        let area = windowFrame
+        let result = ScrollAreaFilter.filterByWindow(areas: [area], windowFrame: windowFrame)
+        #expect(result.count == 1)
+    }
+
+    @Test("Area slightly larger than window (ratio <= 1.5) is kept")
+    func areaSlightlyLargerThanWindowIsKept() {
+        let windowFrame = CGRect(x: 100, y: 100, width: 800, height: 600)
+        // Area is ~20% larger than window: 880x660 = 580800, window = 480000, ratio ≈ 1.21 <= 1.5 → kept
+        let area = CGRect(x: 60, y: 60, width: 880, height: 660)
+        let result = ScrollAreaFilter.filterByWindow(areas: [area], windowFrame: windowFrame)
+        #expect(result.count == 1)
     }
 
     @Test("Area with no intersection is excluded")

--- a/Tests/VimursorTests/ScrollAreaFilterTests.swift
+++ b/Tests/VimursorTests/ScrollAreaFilterTests.swift
@@ -1,0 +1,242 @@
+import Testing
+import CoreGraphics
+@testable import Vimursor
+
+@Suite("ScrollAreaFilter Tests")
+struct ScrollAreaFilterTests {
+
+    // MARK: - filterByWindow
+
+    @Test("Area containing entire window is excluded (desktop-level area)")
+    func areaContainingEntireWindowExcluded() {
+        let windowFrame = CGRect(x: 100, y: 100, width: 800, height: 600)
+        // Area is larger than window and contains it
+        let area = CGRect(x: 0, y: 0, width: 2560, height: 1440)
+        let result = ScrollAreaFilter.filterByWindow(areas: [area], windowFrame: windowFrame)
+        #expect(result.isEmpty)
+    }
+
+    @Test("Area with no intersection is excluded")
+    func areaWithNoIntersectionExcluded() {
+        let windowFrame = CGRect(x: 100, y: 100, width: 800, height: 600)
+        // Area is completely outside window
+        let area = CGRect(x: 1000, y: 1000, width: 400, height: 300)
+        let result = ScrollAreaFilter.filterByWindow(areas: [area], windowFrame: windowFrame)
+        #expect(result.isEmpty)
+    }
+
+    @Test("Area with less than 50% visible is excluded")
+    func areaWithLessThan50PercentVisibleExcluded() {
+        let windowFrame = CGRect(x: 100, y: 100, width: 800, height: 600)
+        // intersection = x:100..900, y:200..700 = 800x500 = 400000
+        // original area = 2000*600 = 1200000
+        // ratio = 400000/1200000 = 33% < 50% → excluded
+        let area2 = CGRect(x: 0, y: 200, width: 2000, height: 600)
+        let result = ScrollAreaFilter.filterByWindow(areas: [area2], windowFrame: windowFrame)
+        #expect(result.isEmpty)
+    }
+
+    @Test("Area fully inside window is kept unchanged")
+    func areaFullyInsideWindowKept() {
+        let windowFrame = CGRect(x: 100, y: 100, width: 800, height: 600)
+        // Area fully inside window
+        let area = CGRect(x: 200, y: 200, width: 300, height: 200)
+        let result = ScrollAreaFilter.filterByWindow(areas: [area], windowFrame: windowFrame)
+        #expect(result.count == 1)
+        #expect(result[0].frame == area)
+        #expect(result[0].originMoved == false)
+    }
+
+    @Test("Area partially outside window is clipped and origin shifted")
+    func areaPartiallyOutsideWindowClipped() {
+        let windowFrame = CGRect(x: 100, y: 100, width: 800, height: 600)
+        // Area extends left beyond window boundary
+        let area = CGRect(x: 50, y: 200, width: 400, height: 200)
+        // intersection: x:100..450, y:200..400 = 350x200
+        let result = ScrollAreaFilter.filterByWindow(areas: [area], windowFrame: windowFrame)
+        #expect(result.count == 1)
+        #expect(result[0].frame.origin.x == 100)  // clipped to window left
+        #expect(result[0].frame.width == 350)
+        #expect(result[0].frame.height == 200)
+        #expect(result[0].originMoved == true)
+    }
+
+    @Test("Area partially outside without origin shift has originMoved=false")
+    func areaClippedRightNoOriginMove() {
+        let windowFrame = CGRect(x: 100, y: 100, width: 800, height: 600)
+        // Area extends right beyond window boundary but origin is inside
+        let area = CGRect(x: 200, y: 200, width: 800, height: 200)
+        // intersection: x:200..900, y:200..400 = 700x200
+        let result = ScrollAreaFilter.filterByWindow(areas: [area], windowFrame: windowFrame)
+        #expect(result.count == 1)
+        #expect(result[0].frame.origin.x == 200)
+        #expect(result[0].frame.width == 700)
+        #expect(result[0].originMoved == false)
+    }
+
+    @Test("Clipped area too small in width is excluded")
+    func clippedAreaTooSmallWidthExcluded() {
+        let windowFrame = CGRect(x: 100, y: 100, width: 800, height: 600)
+        // Area's intersection width < 100
+        let area = CGRect(x: 50, y: 200, width: 120, height: 300)
+        // intersection: x:100..170, y:200..500 = 70x300 → width < 100 → excluded
+        let result = ScrollAreaFilter.filterByWindow(areas: [area], windowFrame: windowFrame)
+        #expect(result.isEmpty)
+    }
+
+    @Test("Clipped area too small in height is excluded")
+    func clippedAreaTooSmallHeightExcluded() {
+        let windowFrame = CGRect(x: 100, y: 100, width: 800, height: 600)
+        // Area's intersection height < 100
+        let area = CGRect(x: 200, y: 50, width: 300, height: 120)
+        // intersection: x:200..500, y:100..170 = 300x70 → height < 100 → excluded
+        let result = ScrollAreaFilter.filterByWindow(areas: [area], windowFrame: windowFrame)
+        #expect(result.isEmpty)
+    }
+
+    @Test("Multiple areas: only valid ones are kept")
+    func multipleAreasFilteredCorrectly() {
+        let windowFrame = CGRect(x: 0, y: 0, width: 1000, height: 800)
+        let areaInsideFrame = CGRect(x: 50, y: 50, width: 400, height: 300)
+        let areaOutsideFrame = CGRect(x: 1100, y: 0, width: 200, height: 200)
+        let result = ScrollAreaFilter.filterByWindow(areas: [areaInsideFrame, areaOutsideFrame], windowFrame: windowFrame)
+        #expect(result.count == 1)
+        #expect(result[0].originalFrame == areaInsideFrame)
+    }
+
+    // MARK: - removeOverlaps
+
+    @Test("No overlapping areas: both kept")
+    func noOverlapBothKept() {
+        let area1 = ScrollAreaFilter.FilteredArea(
+            frame: CGRect(x: 0, y: 0, width: 200, height: 200),
+            originalFrame: CGRect(x: 0, y: 0, width: 200, height: 200),
+            originMoved: false
+        )
+        let area2 = ScrollAreaFilter.FilteredArea(
+            frame: CGRect(x: 300, y: 300, width: 200, height: 200),
+            originalFrame: CGRect(x: 300, y: 300, width: 200, height: 200),
+            originMoved: false
+        )
+        let result = ScrollAreaFilter.removeOverlaps(areas: [area1, area2])
+        #expect(result.count == 2)
+    }
+
+    @Test(">50% overlap, one originMoved: originMoved one excluded")
+    func overlapOneOriginMovedExcluded() {
+        let area1 = ScrollAreaFilter.FilteredArea(
+            frame: CGRect(x: 0, y: 0, width: 200, height: 200),
+            originalFrame: CGRect(x: 0, y: 0, width: 200, height: 200),
+            originMoved: false
+        )
+        // Overlaps heavily with area1, but its origin was moved (it's a partial clipped view)
+        let area2 = ScrollAreaFilter.FilteredArea(
+            frame: CGRect(x: 50, y: 50, width: 200, height: 200),
+            originalFrame: CGRect(x: 50, y: 50, width: 200, height: 200),
+            originMoved: true
+        )
+        // intersection: x:50..200, y:50..200 = 150x150 = 22500
+        // area1 = 40000, area2 = 40000
+        // ratio vs area1: 22500/40000 = 56.25% > 50% → overlap
+        // area2 has originMoved → exclude area2
+        let result = ScrollAreaFilter.removeOverlaps(areas: [area1, area2])
+        #expect(result.count == 1)
+        #expect(result[0].frame == area1.frame)
+    }
+
+    @Test(">50% overlap, both originMoved=false: smaller excluded")
+    func overlapBothNotMovedSmallerExcluded() {
+        let area1 = ScrollAreaFilter.FilteredArea(
+            frame: CGRect(x: 0, y: 0, width: 300, height: 300),
+            originalFrame: CGRect(x: 0, y: 0, width: 300, height: 300),
+            originMoved: false
+        )
+        let area2 = ScrollAreaFilter.FilteredArea(
+            frame: CGRect(x: 50, y: 50, width: 150, height: 150),
+            originalFrame: CGRect(x: 50, y: 50, width: 150, height: 150),
+            originMoved: false
+        )
+        // intersection = 150x150 = 22500
+        // area2 = 22500 → ratio vs area2: 22500/22500 = 100% > 50% → overlap
+        // both originMoved=false → exclude smaller (area2)
+        let result = ScrollAreaFilter.removeOverlaps(areas: [area1, area2])
+        #expect(result.count == 1)
+        #expect(result[0].frame == area1.frame)
+    }
+
+    @Test("<50% overlap: both kept")
+    func lessOverlapBothKept() {
+        let area1 = ScrollAreaFilter.FilteredArea(
+            frame: CGRect(x: 0, y: 0, width: 200, height: 200),
+            originalFrame: CGRect(x: 0, y: 0, width: 200, height: 200),
+            originMoved: false
+        )
+        let area2 = ScrollAreaFilter.FilteredArea(
+            frame: CGRect(x: 150, y: 150, width: 200, height: 200),
+            originalFrame: CGRect(x: 150, y: 150, width: 200, height: 200),
+            originMoved: false
+        )
+        // intersection: x:150..200, y:150..200 = 50x50 = 2500
+        // area1 = 40000, ratio = 2500/40000 = 6.25% < 50% → no overlap
+        let result = ScrollAreaFilter.removeOverlaps(areas: [area1, area2])
+        #expect(result.count == 2)
+    }
+
+    @Test("Three areas with chain overlap: correct exclusions")
+    func threeAreasChainOverlap() {
+        // area1 large, area2 inside area1, area3 separate
+        let area1 = ScrollAreaFilter.FilteredArea(
+            frame: CGRect(x: 0, y: 0, width: 400, height: 400),
+            originalFrame: CGRect(x: 0, y: 0, width: 400, height: 400),
+            originMoved: false
+        )
+        let area2 = ScrollAreaFilter.FilteredArea(
+            frame: CGRect(x: 50, y: 50, width: 200, height: 200),
+            originalFrame: CGRect(x: 50, y: 50, width: 200, height: 200),
+            originMoved: false
+        )
+        let area3 = ScrollAreaFilter.FilteredArea(
+            frame: CGRect(x: 600, y: 0, width: 200, height: 200),
+            originalFrame: CGRect(x: 600, y: 0, width: 200, height: 200),
+            originMoved: false
+        )
+        let result = ScrollAreaFilter.removeOverlaps(areas: [area1, area2, area3])
+        // area2 overlaps >50% with area1 → smaller (area2) excluded
+        // area3 no overlap with area1 → kept
+        #expect(result.count == 2)
+        let frames = result.map { $0.frame }
+        #expect(frames.contains(area1.frame))
+        #expect(frames.contains(area3.frame))
+    }
+
+    // MARK: - Integration: filterByWindow + removeOverlaps pipeline
+
+    @Test("Full pipeline: filterByWindow then removeOverlaps produces correct output")
+    func fullFilterPipelineProducesCorrectOutput() {
+        // Simulate three scroll areas inside a window; one overlaps another heavily
+        let windowFrame = CGRect(x: 0, y: 0, width: 1200, height: 800)
+
+        // area1: sidebar — fully inside window
+        let frame1 = CGRect(x: 0, y: 0, width: 300, height: 800)
+        // area2: main content — fully inside window
+        let frame2 = CGRect(x: 300, y: 0, width: 900, height: 800)
+        // area3: nearly identical to area2 (duplicate — should be removed by dedup)
+        let frame3 = CGRect(x: 300, y: 0, width: 900, height: 800)
+
+        let filtered = ScrollAreaFilter.filterByWindow(
+            areas: [frame1, frame2, frame3],
+            windowFrame: windowFrame
+        )
+        // All three pass the window filter (fully visible, large enough)
+        #expect(filtered.count == 3)
+
+        let deduped = ScrollAreaFilter.removeOverlaps(areas: filtered)
+        // area3 is identical to area2 → 100% overlap → smaller (equal size → first one kept, second excluded)
+        // Result: area1 and one of area2/area3
+        #expect(deduped.count == 2)
+
+        let resultFrames = deduped.map { $0.frame }
+        #expect(resultFrames.contains(frame1))
+        #expect(resultFrames.contains(frame2))
+    }
+}

--- a/Tests/VimursorTests/WebAreaSplitDetectorTests.swift
+++ b/Tests/VimursorTests/WebAreaSplitDetectorTests.swift
@@ -162,7 +162,7 @@ struct WebAreaSplitDetectorTests {
         let result = WebAreaSplitDetector.findSplitFrames(
             children: kids, parentFrame: parent, depth: 0
         )
-        // Header is filtered by wrapperWidthRatio (1470/1470=1.0 >= 0.9).
+        // Header (height=68) is filtered by minChildSize (68 < 100).
         // The two remaining candidates: Y spread = 500-68 = 432 > positionTolerance(50) → horizontal check fails.
         // validateTiling returns false → nil
         #expect(result == nil, "GitHub-likeレイアウトはタイリング検証で拒否される")

--- a/Tests/VimursorTests/WebAreaSplitDetectorTests.swift
+++ b/Tests/VimursorTests/WebAreaSplitDetectorTests.swift
@@ -147,6 +147,112 @@ struct WebAreaSplitDetectorTests {
         #expect(result == nil, "子が0件では分割されない")
     }
 
+    // MARK: - validateTiling Tests
+
+    /// GitHub-like layout: 3 elements with large Y/X spread → rejected
+    @Test("GitHub-like layout: タイリング検証で分割が拒否される")
+    func githubLikeLayoutRejectedByTilingValidation() {
+        // Header-like, main content, another section — not side-by-side
+        let parent = CGRect(x: 0, y: 0, width: 1470, height: 900)
+        let kids = children(frames: [
+            CGRect(x: 0,   y: 0,   width: 1470, height: 68),   // header-like (too small in height, filtered)
+            CGRect(x: 220, y: 68,  width: 1250, height: 400),  // main content
+            CGRect(x: 220, y: 500, width: 1250, height: 400),  // another section
+        ])
+        let result = WebAreaSplitDetector.findSplitFrames(
+            children: kids, parentFrame: parent, depth: 0
+        )
+        // Header is filtered by wrapperWidthRatio (1470/1470=1.0 >= 0.9).
+        // The two remaining candidates: Y spread = 500-68 = 432 > positionTolerance(50) → horizontal check fails.
+        // validateTiling returns false → nil
+        #expect(result == nil, "GitHub-likeレイアウトはタイリング検証で拒否される")
+    }
+
+    /// Slack-like layout: 2 elements side by side → accepted
+    @Test("Slack-like layout: タイリング検証で分割が承認される")
+    func slackLikeLayoutAcceptedByTilingValidation() {
+        let parent = CGRect(x: 0, y: 0, width: 1470, height: 900)
+        let kids = children(frames: [
+            CGRect(x: 0,   y: 0, width: 300,  height: 900),  // sidebar
+            CGRect(x: 300, y: 0, width: 1170, height: 900),  // main
+        ])
+        let result = WebAreaSplitDetector.findSplitFrames(
+            children: kids, parentFrame: parent, depth: 0
+        )
+        #expect(result?.count == 2, "Slack-likeレイアウトはタイリング検証を通過して2分割される")
+    }
+
+    /// Vertical stacking (same-width elements): NOT a valid split — stacked content sections
+    @Test("垂直スタック: 同幅の要素が縦に並ぶ場合は分割されない（コンテンツセクション）")
+    func verticalStackingRejected() {
+        // Two same-width elements stacked vertically = content sections, not independent panes
+        let parent = CGRect(x: 0, y: 0, width: 1000, height: 800)
+        let kids = children(frames: [
+            CGRect(x: 0, y: 0,   width: 800, height: 380),
+            CGRect(x: 0, y: 400, width: 800, height: 400),
+        ])
+        let result = WebAreaSplitDetector.findSplitFrames(
+            children: kids, parentFrame: parent, depth: 0
+        )
+        #expect(result == nil, "垂直スタックはコンテンツセクションとして分割されない")
+    }
+
+    /// validateTiling direct test: horizontal valid
+    @Test("validateTiling: 水平タイリングが有効な場合 true を返す")
+    func validateTilingHorizontalValid() {
+        let parent = CGRect(x: 0, y: 0, width: 1470, height: 900)
+        let candidates = [
+            CGRect(x: 0,   y: 0, width: 300,  height: 900),
+            CGRect(x: 300, y: 0, width: 1170, height: 900),
+        ]
+        #expect(WebAreaSplitDetector.validateTiling(candidates: candidates, parentFrame: parent) == true)
+    }
+
+    /// validateTiling direct test: horizontal invalid (large Y spread)
+    @Test("validateTiling: Y スプレッドが大きい場合 false を返す")
+    func validateTilingHorizontalInvalidYSpread() {
+        let parent = CGRect(x: 0, y: 0, width: 1470, height: 900)
+        let candidates = [
+            CGRect(x: 220, y: 68,  width: 1250, height: 400),
+            CGRect(x: 220, y: 500, width: 1250, height: 400),
+        ]
+        #expect(WebAreaSplitDetector.validateTiling(candidates: candidates, parentFrame: parent) == false)
+    }
+
+    /// validateTiling direct test: vertical stacking (same-width) → false (horizontal-only validation)
+    @Test("validateTiling: 垂直スタック（同幅）は false を返す（水平タイリングのみ有効）")
+    func validateTilingVerticalStackingReturnsFalse() {
+        let parent = CGRect(x: 0, y: 0, width: 1000, height: 800)
+        let candidates = [
+            CGRect(x: 0, y: 0,   width: 800, height: 380),
+            CGRect(x: 0, y: 400, width: 800, height: 400),
+        ]
+        // Vertical stacking of same-width content = content sections, not independent scroll panes
+        #expect(WebAreaSplitDetector.validateTiling(candidates: candidates, parentFrame: parent) == false)
+    }
+
+    /// validateTiling direct test: large gaps between candidates → false
+    @Test("validateTiling: 候補間のギャップが大きい場合 false を返す")
+    func validateTilingLargeGap() {
+        let parent = CGRect(x: 0, y: 0, width: 1000, height: 800)
+        let candidates = [
+            CGRect(x: 0,   y: 0, width: 200, height: 800),
+            CGRect(x: 700, y: 0, width: 200, height: 800),  // gap = 500 > maxGap(50)
+        ]
+        #expect(WebAreaSplitDetector.validateTiling(candidates: candidates, parentFrame: parent) == false)
+    }
+
+    /// validateTiling direct test: insufficient coverage → false
+    @Test("validateTiling: カバレッジが不十分な場合 false を返す")
+    func validateTilingInsufficientCoverage() {
+        let parent = CGRect(x: 0, y: 0, width: 1000, height: 800)
+        let candidates = [
+            CGRect(x: 0,  y: 0, width: 100, height: 800),
+            CGRect(x: 100, y: 0, width: 100, height: 800),  // total width = 200, 200/1000 = 0.2 < 0.7
+        ]
+        #expect(WebAreaSplitDetector.validateTiling(candidates: candidates, parentFrame: parent) == false)
+    }
+
     // MARK: - wrapperWidthRatio 境界値テスト
 
     /// 幅が parentWidth * 0.9 ちょうどの子はラッパーとみなして再帰する


### PR DESCRIPTION
## Summary

スクロールモードで非スクロール領域を誤検出する問題を修正。タイリング検証とウィンドウ可視領域フィルタリングにより、汎用的な誤検出防止を実現。

## Changes

- WebAreaSplitDetector にタイリング検証（`validateTiling`）を追加し、水平に並ばない候補の誤分割を拒否
- ScrollAreaFilter を新設し、ウィンドウ外領域の除外・クリップ後の重複除去を実装
- AXManager にフォーカスウィンドウのフレーム取得（`focusedWindowFrame`）を追加
- ScrollTarget にウィンドウフレームパラメータを追加し、フィルタパイプラインを統合

## Related Issues

Epic: #164
Closes #164, Closes #165, Closes #166

## Self-Review Checklist

- [x] I've reviewed my own diff
- [x] Tests cover the new/changed behavior
- [x] `swift build` passes
- [x] `swift test` passes
- [x] Manual testing completed

## Test Plan

- [x] GitHub リポジトリページ（Chrome）でスクロール領域が1つのみ検出される
- [x] Slack でサイドバー + メインの2領域が正しく検出される
- [x] Notion でサイドバー + メインの2領域が正しく検出される
- [x] Finder でデスクトップ・ウィンドウ外カラムが除外される
- [x] `swift test` 全247テスト通過